### PR TITLE
Add a manifest for the ANTS Framework

### DIFF
--- a/ApplicationsManagedPreferences/ANTSConfigProfile.plist
+++ b/ApplicationsManagedPreferences/ANTSConfigProfile.plist
@@ -1,0 +1,425 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>pfm_app_documentation_url</key>
+	<string>https://ants-framework.github.io</string>
+	<key>pfm_app_url</key>
+	<string>https://github.com/ANTS-Framework/ants</string>
+	<key>pfm_description</key>
+	<string>ANTS Framework settings</string>
+	<key>pfm_domain</key>
+	<string>com.github.ants-framework</string>
+	<key>pfm_format_version</key>
+	<integer>1</integer>
+	<key>pfm_icon</key>
+	<data></data>
+	<key>pfm_last_modified</key>
+	<date>2018-07-12T11:54:43Z</date>
+	<key>pfm_subkeys</key>
+	<array>
+		<dict>
+			<key>pfm_default</key>
+			<string>Configures the ANTS framework configuration preferences</string>
+			<key>pfm_description</key>
+			<string>Description of the payload</string>
+			<key>pfm_name</key>
+			<string>PayloadDescription</string>
+			<key>pfm_title</key>
+			<string>Payload Description</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>ANTS Framework settings</string>
+			<key>pfm_description</key>
+			<string>Name of the payload</string>
+			<key>pfm_name</key>
+			<string>PayloadDisplayName</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Display Name</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>ants-framework</string>
+			<key>pfm_description</key>
+			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<key>pfm_name</key>
+			<string>PayloadIdentifier</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Identifier</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string></string>
+			<key>pfm_description</key>
+			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<key>pfm_format</key>
+			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
+			<key>pfm_name</key>
+			<string>PayloadUUID</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload UUID</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<integer>1</integer>
+			<key>pfm_description</key>
+			<string>The version of the whole configuration profile.</string>
+			<key>pfm_name</key>
+			<string>PayloadVersion</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Version</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<key>pfm_name</key>
+			<string>PayloadOrganization</string>
+			<key>pfm_title</key>
+			<string>Payload Organization</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_name</key>
+			<string>PFC_SegmentedControl_0</string>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>General</string>
+				<string>Active Directory</string>
+			</array>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_segments</key>
+			<dict>
+				<key>General</key>
+				<array>
+					<string>main</string>
+				</array>
+				<key>Active Directory</key>
+				<array>
+					<string>ad</string>
+				</array>
+			</dict>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>General</string>
+			<key>pfm_hidden</key>
+			<string>container</string>
+			<key>pfm_name</key>
+			<string>main</string>
+			<key>pfm_required</key>
+			<true/>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_default</key>
+					<string>https://github.com/ANTS-Framework/playbook.git</string>
+					<key>pfm_description</key>
+					<string>URL of the repository that contains your Ansible playbooks.</string>
+					<key>pfm_name</key>
+					<string>git_repository</string>
+					<key>pfm_title</key>
+					<string>Git Repository</string>
+					<key>pfm_required</key>
+					<true/>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_default</key>
+					<string>master</string>
+					<key>pfm_description</key>
+					<string>Git branch to check out from your Git repository.</string>
+					<key>pfm_name</key>
+					<string>branch</string>
+					<key>pfm_title</key>
+					<string>Branch</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_default</key>
+					<string>/etc/ants/id_ants</string>
+					<key>pfm_description</key>
+					<string>Absolute path to a SSH key with permission to access your Git repository.</string>
+					<key>pfm_name</key>
+					<string>ssh_key</string>
+					<key>pfm_title</key>
+					<string>SSH Key</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_default</key>
+					<string>~root/.ants_playbook</string>
+					<key>pfm_description</key>
+					<string>Absolute path on the local machine to heck out your Git repository.</string>
+					<key>pfm_name</key>
+					<string>destination</string>
+					<key>pfm_title</key>
+					<string>Destination</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_default</key>
+					<string>inventory_default</string>
+					<key>pfm_description</key>
+					<string>Relative or absolute path to an ansible inventory script.</string>
+					<key>pfm_name</key>
+					<string>inventory_script</string>
+					<key>pfm_title</key>
+					<string>Inventory Script</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_default</key>
+					<integer>900</integer>
+					<key>pfm_description</key>
+					<string>The number of seconds to wait in between ansible-pull runs.</string>
+					<key>pfm_name</key>
+					<string>wait_interval</string>
+					<key>pfm_title</key>
+					<string>Wait Interval</string>
+					<key>pfm_type</key>
+					<string>integer</string>
+				</dict>
+				<dict>
+					<key>pfm_default</key>
+					<string>main.yml</string>
+					<key>pfm_description</key>
+					<string>File name of the primary Ansible playbook to run relative to your &lt;Destination&gt; directory.</string>
+					<key>pfm_name</key>
+					<string>ansible_playbook</string>
+					<key>pfm_title</key>
+					<string>Ansible Playbook</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_default</key>
+					<string>/var/log/ants</string>
+					<key>pfm_description</key>
+					<string>Absolute path of where to store log files from runs.</string>
+					<key>pfm_name</key>
+					<string>log_dir</string>
+					<key>pfm_title</key>
+					<string>Log Directory</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_default</key>
+					<false/>
+					<key>pfm_description</key>
+					<string>Whether or not to use strict host key checking when running Git commands.</string>
+					<key>pfm_name</key>
+					<string>ssh_stricthostkeychecking</string>
+					<key>pfm_title</key>
+					<string>Strict Host Key Checking</string>
+					<key>pfm_required</key>
+					<true/>
+					<key>pfm_type</key>
+					<string>boolean</string>
+				</dict>
+				<dict>
+					<key>pfm_default</key>
+					<string></string>
+					<key>pfm_description</key>
+					<string>Absolute path to a different ansible-pull binary installed on the local machine.</string>
+					<key>pfm_name</key>
+					<string>ansible_pull_exe</string>
+					<key>pfm_title</key>
+					<string>Ansible Pull</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_default</key>
+					<string></string>
+					<key>pfm_description</key>
+					<string>Limit the Ansible playbook run to a comma separated list of tags.</string>
+					<key>pfm_name</key>
+					<string>tags</string>
+					<key>pfm_title</key>
+					<string>Tags</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_default</key>
+					<string></string>
+					<key>pfm_description</key>
+					<string>Run the Ansible playbook on all tags except the provided comma separated list.</string>
+					<key>pfm_name</key>
+					<string>skip_tags</string>
+					<key>pfm_title</key>
+					<string>Skip Tags</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+			</array>
+			<key>pfm_title</key>
+			<string>General</string>
+			<key>pfm_type</key>
+			<string>dictionary</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Active Directory</string>
+			<key>pfm_hidden</key>
+			<string>container</string>
+			<key>pfm_name</key>
+			<string>ad</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_default</key>
+					<string>ldap\changeme</string>
+					<key>pfm_description</key>
+					<string>User name to use to connect to LDAP.</string>
+					<key>pfm_name</key>
+					<string>ldap_user</string>
+					<key>pfm_title</key>
+					<string>LDAP User</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_default</key>
+					<string>changeme</string>
+					<key>pfm_description</key>
+					<string>Password to use to connect to LDAP.</string>
+					<key>pfm_name</key>
+					<string>ldap_pw</string>
+					<key>pfm_title</key>
+					<string>LDAP Password</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_default</key>
+					<string>LDAP.PRETENDCORP.COM</string>
+					<key>pfm_description</key>
+					<string>LDAP server to connect to for inventory purposes.</string>
+					<key>pfm_name</key>
+					<string>ldap_host</string>
+					<key>pfm_title</key>
+					<string>LDAP Host</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_default</key>
+					<string>DC=ldap,DC=pretendcorp,DC=com</string>
+					<key>pfm_description</key>
+					<string>LDAP location of computer objects.</string>
+					<key>pfm_name</key>
+					<string>ldap_ou_computers</string>
+					<key>pfm_title</key>
+					<string>LDAP OU Computers</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_default</key>
+					<string>OU=ants,OU=Groups,DC=ldap,DC=pretendcorp,DC=com</string>
+					<key>pfm_description</key>
+					<string>LDAP location of group objects.</string>
+					<key>pfm_name</key>
+					<string>ldap_ou_groups</string>
+					<key>pfm_title</key>
+					<string>LDAP OU Groups</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_default</key>
+					<string>/etc/ants/inventory_cache.json</string>
+					<key>pfm_description</key>
+					<string>Absolute path to a cache file of Active Directory results.</string>
+					<key>pfm_name</key>
+					<string>cache_file</string>
+					<key>pfm_title</key>
+					<string>Cache File</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_default</key>
+					<string>ants-</string>
+					<key>pfm_description</key>
+					<string>Group prefix used to filter groups from Active Directory.</string>
+					<key>pfm_name</key>
+					<string>group_prefix</string>
+					<key>pfm_title</key>
+					<string>Group Prefix</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_default</key>
+					<string>ants-common</string>
+					<key>pfm_description</key>
+					<string>A common group to put all computers in.</string>
+					<key>pfm_name</key>
+					<string>common_group</string>
+					<key>pfm_title</key>
+					<string>Common Group</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_default</key>
+					<string>common_ad_connected</string>
+					<key>pfm_description</key>
+					<string>A common group that computers are put in when the inventory script actively connects to Active Directory.</string>
+					<key>pfm_name</key>
+					<string>common_ad_connected</string>
+					<key>pfm_title</key>
+					<string>Common AD Connected</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+			</array>
+			<key>pfm_title</key>
+			<string>Active Directory</string>
+			<key>pfm_type</key>
+			<string>dictionary</string>
+		</dict>
+	</array>
+	<key>pfm_targets</key>
+	<array>
+		<string>system</string>
+	</array>
+	<key>pfm_title</key>
+	<string>ANTS Framework</string>
+	<key>pfm_unique</key>
+	<true/>
+	<key>pfm_version</key>
+	<integer>1</integer>
+</dict>
+</plist>


### PR DESCRIPTION
The ANTS Framework helps set up ansible in pull mode to manage
a mac computer. This manifest has all keys available to configure
the ANTS Framework. Any value not set via profile will default to
the local ants.cfg file.

![image](https://user-images.githubusercontent.com/4534275/42711412-c063de7c-86b5-11e8-9fec-1d0ad4e9d792.png)

The ANTS Profile is a MCX profile that has the format similar to this

```
<key>mcx_preference_settings</key>
<dict>
    <key>main</key>
    <dict>
        <key>wait_interval</key>
        <integer>900</integer>
        <key>inventory_script</key>
        <string>inventory_default</string>
        <key>destination</key>
        <string>~root/.ants_playbook</string>
        <key>ssh_key</key>
        <string>/etc/ants/id_ants</string>
        <key>ssh_stricthostkeychecking</key>
        <false/>
        <key>git_repository</key>
        <string>https://github.com/ANTS-Framework/playbook.git</string>
        <key>log_dir</key>
        <string>/var/log/ants</string>
        <key>branch</key>
        <string>master</string>
        <key>ansible_pull_exe</key>
        <string></string>
        <key>ansible_playbook</key>
        <string>main.yml</string>
    </dict>
    <key>ad</key>
    <dict>
        <key>ldap_user</key>
        <string>ldap\changeme</string>
        <key>ldap_pw</key>
        <string>changeme</string>
        <key>ldap_host</key>
        <string>LDAP.PRETENDCORP.COM</string>
        <key>ldap_ou_computers</key>
        <string>DC=ldap,DC=pretendcorp,DC=com</string>
        <key>ldap_ou_groups</key>
        <string>OU=ants,OU=Groups,DC=ldap,DC=pretendcorp,DC=com</string>
        <key>cache_file</key>
        <string>/etc/ants/inventory_cache.json</string>
        <key>group_prefix</key>
        <string>ants-</string>
        <key>common_group</key>
        <string>ants-common</string>
        <key>common_ad_connected</key>
        <string>common-ad-connected</string>
    </dict>
</dict>
```

The consensus in the #ansible channel on the Mac Admins slack was that the github repo and strict host key checking flag should be required. I could not figure out how to move those two entries outside of the segmented control while still having them nested under either the `main` or `ad` keys. Additionally I wasn't sure how the image data worked but there is an image here that can be used inside ProfileCreator

https://avatars0.githubusercontent.com/u/31036978?s=200&v=4
![31036978](https://user-images.githubusercontent.com/4534275/42711521-3210fb54-86b6-11e8-826c-c2503e77db87.png)
