### PR TITLE
Remove MERP app registration

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
@@ -590,49 +590,6 @@
 					<key>pfm_type</key>
 					<string>dictionary</string>
 				</dict>
-				<dict>
-					<key>pfm_default</key>
-					<true/>
-					<key>pfm_description</key>
-					<string>Register /Library/Application Support/Microsoft/MERP2.0/Microsoft Error Reporting.app.</string>
-					<key>pfm_name</key>
-					<string>/Library/Application Support/Microsoft/MERP2.0/Microsoft Error Reporting.app</string>
-					<key>pfm_subkeys</key>
-					<array>
-						<dict>
-							<key>pfm_default</key>
-							<string>Merp2</string>
-							<key>pfm_hidden</key>
-							<string>all</string>
-							<key>pfm_name</key>
-							<string>Application ID</string>
-							<key>pfm_require</key>
-							<string>always</string>
-							<key>pfm_title</key>
-							<string>Error Reporting Application ID</string>
-							<key>pfm_type</key>
-							<string>string</string>
-						</dict>
-						<dict>
-							<key>pfm_default</key>
-							<integer>1033</integer>
-							<key>pfm_hidden</key>
-							<string>all</string>
-							<key>pfm_name</key>
-							<string>LCID</string>
-							<key>pfm_require</key>
-							<string>always</string>
-							<key>pfm_title</key>
-							<string>Error Reporting Language Code ID</string>
-							<key>pfm_type</key>
-							<string>integer</string>
-						</dict>
-					</array>
-					<key>pfm_title</key>
-					<string>Microsoft Error Reporting</string>
-					<key>pfm_type</key>
-					<string>dictionary</string>
-				</dict>
 			</array>
 			<key>pfm_title</key>
 			<string>Applications</string>
@@ -766,4 +723,4 @@
 	<key>pfm_version</key>
 	<integer>6</integer>
 </dict>
-</plist>
+</plist>		


### PR DESCRIPTION
Removes Microsoft Error Reporting from the application registration section based on confirmation that it isn't needed from @pbowden-msft in Slack: https://macadmins.slack.com/archives/C07UZ1X7B/p1537570599000100