### PR TITLE
Added SUDisableEVCheck key to com.apple.SoftwareUpdate.plist

### DIFF
--- a/Manifests/ManifestsApple/com.apple.SoftwareUpdate.plist
+++ b/Manifests/ManifestsApple/com.apple.SoftwareUpdate.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:49Z</date>
+	<date>2018-11-08T02:53:44Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -124,6 +124,18 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
+			<string>This option was needed during Mojave betas which required https.</string>
+			<key>pfm_macos_min</key>
+			<string>10.14</string>
+			<key>pfm_name</key>
+			<string>SUDisableEVCheck</string>
+			<key>pfm_title</key>
+			<string>Disable Extended Validation check of TLS certificate.</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_name</key>
 			<string>AllowPreReleaseInstallation</string>
@@ -217,6 +229,6 @@ Availability: Available in macOS 10.14 and later.</string>
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>


### PR DESCRIPTION
Attempt to add the `SUDisableEVCheck` key to the `com.apple.SoftwareUpdate.plist` profile.

This key was needed during Mojave betas but reports have varied with the public releases.