### PR TITLE
Update com.apple.dock.plist

### DIFF
--- a/Manifests/ManifestsApple/com.apple.dock.plist
+++ b/Manifests/ManifestsApple/com.apple.dock.plist
@@ -7,7 +7,7 @@
 	<key>pfm_description_reference</key>
 	<string>The Dock payload is designated by specifying com.apple.dock as the PayloadType.
 The Dock payload is supported on the user channel and, except for AllowDockFixupOverride, on all version of
-macOS. The key AllowDockFixupOverride is supported on macOS 10.12 and later.</string>
+macOS. The key AllowDockFixupOverride is supported on macOS 10.12 and later. The key show-recents is supported on macOS 10.14 and later.</string>
 	<key>pfm_domain</key>
 	<string>com.apple.dock</string>
 	<key>pfm_format_version</key>
@@ -15,7 +15,7 @@ macOS. The key AllowDockFixupOverride is supported on macOS 10.12 and later.</st
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2018-08-30T17:54:12Z</date>
+	<date>2018-12-10T12:22:47Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -1093,6 +1093,20 @@ The payload organization for a payload need not match the payload organization i
 			<string>show-process-indicators</string>
 			<key>pfm_title</key>
 			<string>Show indicators for open applications</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>Set to true to show recent applications in the Dock.</string>
+			<key>pfm_description_reference</key>
+			<string>If true, the three most recent applications will be shown in the Dock.</string>
+			<key>pfm_name</key>
+			<string>show-recents</string>
+			<key>pfm_title</key>
+			<string>Show recent applications in Dock</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>


### PR DESCRIPTION
Addition of show-recents covering the 'Show recent applications in Dock' introduced in Mojave.