### PR TITLE
Add Platypus manifest & Add Plugins to Munki manifest

### DIFF
--- a/Manifests/ManagedPreferencesApplications/ManagedInstalls.plist
+++ b/Manifests/ManagedPreferencesApplications/ManagedInstalls.plist
@@ -16,7 +16,7 @@
 	<data>
 	</data>
 	<key>pfm_last_modified</key>
-	<date>2018-09-05T06:42:32Z</date>
+	<date>2018-12-15T16:06:00Z</date>
 	<key>pfm_subkeys</key>
 	<array>
 		<dict>
@@ -135,6 +135,7 @@
 				<string>URL</string>
 				<string>Certificate</string>
 				<string>Log</string>
+				<string>Plugins</string>
 			</array>
 			<key>pfm_require</key>
 			<string>always</string>
@@ -182,6 +183,13 @@
 					<string>ShowOptionalInstallsForHigherOSVersions</string>
 					<string>DaysBetweenNotifications</string>
 					<string>UseNotificationCenterDays</string>
+				</array>
+				<key>Plugins</key>
+				<array>
+					<string>PFC_SegementedControl_Plugins</string>
+					<string>AccessKey</string>
+					<string>SecretKey</string>
+					<string>Region</string>
 				</array>
 				<key>URL</key>
 				<array>
@@ -624,12 +632,81 @@
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
+		<dict>
+			<key>pfm_name</key>
+			<string>PFC_SegmentedControl_Plugins</string>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>S3-Auth</string>
+			</array>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_segments</key>
+			<dict>
+				<key>S3-Auth</key>
+				<array>
+					<string>AccessKey</string>
+					<string>SecretKey</string>
+					<string>Region</string>
+				</array>
+			</dict>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>2.7.0</string>
+			<key>pfm_description</key>
+			<string>Munki has a feature which enables Mac administrators to use middleware to change munki's HTTP request. S3-Auth uses this feature to create the HTTP headers necessary to authenticate to S3.
+
+AccessKey for S3 bucket.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/waderobson/s3-auth</string>
+			<key>pfm_name</key>
+			<string>AccessKey</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_value_placeholder</key>
+			<string>ex. AKIAIX2QPWZ7EXAMPLE</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>2.7.0</string>
+			<key>pfm_description</key>
+			<string>Munki has a feature which enables Mac administrators to use middleware to change munki's HTTP request. S3-Auth uses this feature to create the HTTP headers necessary to authenticate to S3.
+
+Region for S3 bucket.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/waderobson/s3-auth</string>
+			<key>pfm_name</key>
+			<string>Region</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_value_placeholder</key>
+			<string>ex. us-west-2</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>2.7.0</string>
+			<key>pfm_description</key>
+			<string>Munki has a feature which enables Mac administrators to use middleware to change munki's HTTP request. S3-Auth uses this feature to create the HTTP headers necessary to authenticate to S3.
+
+SecretKey for S3 bucket.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/waderobson/s3-auth</string>
+			<key>pfm_name</key>
+			<string>SecretKey</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_value_placeholder</key>
+			<string>ex. z5MFJCcEyYBmh2BxbrlZBWNJ4izEXAMPLE</string>
+		</dict>
 	</array>
 	<key>pfm_title</key>
 	<string>Munki</string>
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/org.sveinbjorn.Platypus.plist
+++ b/Manifests/ManagedPreferencesApplications/org.sveinbjorn.Platypus.plist
@@ -1,0 +1,264 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>pfm_app_url</key>
+	<string>https://sveinbjorn.org/platypus</string>
+	<key>pfm_description</key>
+	<string>Platypus settings</string>
+	<key>pfm_documentation</key>
+	<string>https://sveinbjorn.org/files/manpages/PlatypusDocumentation.html</string>
+	<key>pfm_domain</key>
+	<string>org.sveinbjorn.Platypus</string>
+	<key>pfm_format_version</key>
+	<integer>1</integer>
+	<key>pfm_icon</key>
+	<data>
+	</data>
+	<key>pfm_last_modified</key>
+	<date>2018-12-12T18:50:49Z</date>
+	<key>pfm_subkeys</key>
+	<array>
+		<dict>
+			<key>pfm_default</key>
+			<string>Configures Platypus settings</string>
+			<key>pfm_description</key>
+			<string>Description of the payload</string>
+			<key>pfm_name</key>
+			<string>PayloadDescription</string>
+			<key>pfm_title</key>
+			<string>Payload Description</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>Platypus</string>
+			<key>pfm_description</key>
+			<string>Name of the payload</string>
+			<key>pfm_name</key>
+			<string>PayloadDisplayName</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Display Name</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>org.sveinbjorn.Platypus</string>
+			<key>pfm_description</key>
+			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<key>pfm_name</key>
+			<string>PayloadIdentifier</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Identifier</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>org.sveinbjorn.Platypus</string>
+			<key>pfm_description</key>
+			<string>The type of the payload, a reverse dns string.</string>
+			<key>pfm_name</key>
+			<string>PayloadType</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Type</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string></string>
+			<key>pfm_description</key>
+			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<key>pfm_format</key>
+			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
+			<key>pfm_name</key>
+			<string>PayloadUUID</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload UUID</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<integer>1</integer>
+			<key>pfm_description</key>
+			<string>The version of the whole configuration profile.</string>
+			<key>pfm_name</key>
+			<string>PayloadVersion</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Version</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
+			<key>pfm_name</key>
+			<string>PayloadOrganization</string>
+			<key>pfm_title</key>
+			<string>Payload Organization</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_name</key>
+			<string>PFC_SegmentedControl_0</string>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>General</string>
+				<string>Updates</string>
+			</array>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_segments</key>
+			<dict>
+				<key>General</key>
+				<array>
+					<string>DefaultBundleIdentifierPrefix</string>
+					<string>DefaultAuthor</string>
+					<string>DefaultEditor</string>
+					<string>RevealApplicationWhenCreated</string>
+					<string>OpenApplicationWhenCreated</string>
+				</array>
+				<key>Updates</key>
+				<array>
+					<string>SUAutomaticallyUpdate</string>
+					<string>SUEnableAutomaticChecks</string>
+					<string>SUFeedURL</string>
+					<string>SUSendProfileInfo</string>
+				</array>
+			</dict>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Enter the desired default bundle identifier prefix for apps built with Platypus. This string must end with a period.</string>
+			<key>pfm_name</key>
+			<string>DefaultBundleIdentifierPrefix</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_value_placeholder</key>
+			<string>org.yours.theapp.</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>The default name to have listed as the application author.</string>
+			<key>pfm_name</key>
+			<string>DefaultAuthor</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_value_placeholder</key>
+			<string>YOUR ORG/NAME HERE</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>The default text editor to use with Platypus. If you want to use built-in Platypus editor, don't enable this preference.</string>
+			<key>pfm_name</key>
+			<string>DefaultEditor</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>Atom</string>
+				<string>BBEdit</string>
+				<string>Sublime Text</string>
+				<string>TextEdit</string>
+			</array>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>After building an application with Platypus, reveal the application in the Finder.</string>
+			<key>pfm_name</key>
+			<string>RevealApplicationWhenCreated</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>After building an appliction with Platypus, launch the application.</string>
+			<key>pfm_name</key>
+			<string>OpenApplicationWhenCreated</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Automatically download available updates for Platypus. When combined with SUEnableAutomaticChecks, Platypus will automatically check and download these updates. Updates are subsequently installed when the user quits the app.</string>
+			<key>pfm_description_reference</key>
+			<string>When set to false, Platypus will not automatically download software updates.</string>
+			<key>pfm_exclude</key>
+			<array>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_present</key>
+							<false/>
+							<key>pfm_target</key>
+							<string>SUEnableAutomaticChecks</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
+			<key>pfm_name</key>
+			<string>SUAutomaticallyUpdate</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>Automatically check for Platypus software updates.</string>
+			<key>pfm_description_reference</key>
+			<string>When set to false, Platypus will not automatically check for software updates.</string>
+			<key>pfm_name</key>
+			<string>SUEnableAutomaticChecks</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Sparkle update framework key. While automatic update checks can be disabled via the SUEnableAutomaticChecks key, this does not prevent users from manually running a software update check via the GUI. Setting this key to a non-existant local address will prevent users from manually triggering and/or installing updates themselves.</string>
+			<key>pfm_description_reference</key>
+			<string>When set to a non-existant local address, DetectX Swift will be unable to determine if updates are available.</string>
+			<key>pfm_name</key>
+			<string>SUFeedURL</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_value_placeholder</key>
+			<string>http://127.0.0.1</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>When running software update checks, submit anonymous computer profile data to Platypus.</string>
+			<key>pfm_description_reference</key>
+			<string>When set to false, will not submit this anonymous computer profile data.</string>
+			<key>pfm_name</key>
+			<string>SUSendProfileInfo</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+	</array>
+	<key>pfm_title</key>
+	<string>Platypus</string>
+	<key>pfm_unique</key>
+	<true/>
+	<key>pfm_version</key>
+	<integer>1</integer>
+</dict>
+</plist>


### PR DESCRIPTION
In the munki manifest I added a new "Plugins" menu.  At the moment this only has S3-Auth (https://github.com/waderobson/s3-auth) preferences, but thought this structure would work for future plugin additions.

An important note, I'm not sure why, but the S3-Auth menu appears at the very bottom of the "General", "Managed Software Center", "URL", etc. menus with none of the keys.  However, "S3-Auth" and the proper keys are listed in Plugins.  I looked at my code and other examples but I can't seem to find why "S3-Auth" isn't only showing in Plugins.  Hope you might help on that front 😅 