### PR TITLE
Profile Manifest for Firefox Preferences

### DIFF
--- a/Manifests/ManagedPreferencesApplications/org.mozilla.firefox.plist
+++ b/Manifests/ManagedPreferencesApplications/org.mozilla.firefox.plist
@@ -1718,6 +1718,8 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 						<string>Optional. Select SOCKS Version.</string>
 						<key>pfm_name</key>
 						<string>SOCKSVersion</string>
+						<key>pfm_title</key>
+						<string>SOCKS Version</string>
 						<key>pfm_type</key>
 						<string>string</string>
 						<key>pfm_range_list</key>


### PR DESCRIPTION
Here is the first profile manifest for Firefox preferences based off the plist template https://github.com/mozilla/policy-templates/blob/master/mac/org.mozilla.firefox.plist. A couple of notes:
1. Verbiage was taken from a mix of the README on https://github.com/mozilla/policy-templates and the Windows GPO ADM definitions. I've replaced where applicable references to the word "policy" for "preference" since the target audience are macOS administrators.
2. I've made use of segmented controls to better categorize the long list of preferences. Those categories are:
General > General	
General > Add-ons	
General > Bookmarks	
General > Languages	
Network	
Privacy > General	
Privacy > Cookies	
Privacy > Permissions	
Security > General	
Security > Certificates	

3. The preference key `Proxy` has too variations in which other keys may require that other keys are selected. If you open up Network Settings in Firefox, you can see the variations and which fields are required depending on what you select. I was unable to find a way to make requirements here that made sense.

4. I cannot make sense of the preference key `SecurityDevices`. It is included but I'm not entirely sure whether it will work or not as the key:value names given do not make much sense in usage for a Configuration Profile.

5. There is an area for improvement in the preference key `Permissions` which has quite a few nested dictionaries. I was thinking of making a segmented control here, but open to feedback for better ease of use.

6. I've added pfm_title keys where it made sense for all the high level preference keys. There are situations where nested keys do not have pfm_title keys and could probably use them, but the descriptions should make it clear what the keys do.

7. Given that this is the first iteration I'm comfortable submitting, I've titled it Mozilla Firefox (Testing) so others can use it with knowledge that it hasn't been widely tested.