### PR TITLE
Update com.apple.applicationaccess.plist

### DIFF
--- a/Manifests/ManifestsApple/com.apple.applicationaccess.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess.plist
@@ -628,7 +628,7 @@ Availability: Available in iOS 11.3 and later and macOS 10.13.4 and later.</stri
 			<key>pfm_range_max</key>
 			<integer>90</integer>
 			<key>pfm_range_min</key>
-			<integer>0</integer>
+			<integer>1</integer>
 			<key>pfm_title</key>
 			<string>Deferred Software Updates Delay</string>
 			<key>pfm_type</key>
@@ -647,6 +647,6 @@ Availability: Available in iOS 11.3 and later and macOS 10.13.4 and later.</stri
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>3</integer>
+	<integer>4</integer>
 </dict>
 </plist>


### PR DESCRIPTION
Very small change, but confirmed that the minimum days cannot be 0.  Per https://github.com/erikberglund/ProfileManifests/issues/38