### PR TITLE
Clean, reorganize, and minor logic manifest updates

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.apple.logic10.plist
+++ b/Manifests/ManagedPreferencesApplications/com.apple.logic10.plist
@@ -2,34 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-
 	<key>pfm_app_url</key>
 	<string>https://apple.com/logic-pro/</string>
-	<key>pfm_documentation_url</key>
-	<string></string>
-	<key>pfm_targets</key>
-	<array>
-		<string>system</string>
-        <string>user</string>
-	</array>
-	<key>pfm_platforms</key>
-	<array>
-		<string>macOS</string>
-	</array>
 	<key>pfm_description</key>
 	<string>Logic Pro X settings</string>
+	<key>pfm_documentation_url</key>
+	<string></string>
 	<key>pfm_domain</key>
 	<string>com.apple.logic10</string>
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2018-12-11T12:00:00Z</date>
-	<key>pfm_title</key>
-	<string>Logic Pro X</string>
-	<key>pfm_unique</key>
-	<false/>
-	<key>pfm_version</key>
-	<integer>1</integer>
+	<date>2019-02-24T12:00:00Z</date>
+	<key>pfm_platforms</key>
+	<array>
+		<string>macOS</string>
+	</array>
 	<key>pfm_subkeys</key>
 	<array>
 		<dict>
@@ -46,7 +34,6 @@
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>
-
 		<dict>
 			<key>pfm_default</key>
 			<string>Logic Pro X</string>
@@ -63,7 +50,6 @@
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>
-
 		<dict>
 			<key>pfm_default</key>
 			<string>com.apple.logic10</string>
@@ -80,7 +66,6 @@
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>
-		
 		<dict>
 			<key>pfm_default</key>
 			<string>com.apple.logic10</string>
@@ -97,7 +82,6 @@
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>
-		
 		<dict>
 			<key>pfm_description</key>
 			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
@@ -114,7 +98,6 @@
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>
-		
 		<dict>
 			<key>pfm_default</key>
 			<integer>1</integer>
@@ -132,7 +115,6 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_type</key>
 			<string>integer</string>
 		</dict>
-		
 		<dict>
 			<key>pfm_description</key>
 			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
@@ -143,144 +125,144 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>
-	
 		<dict>
+			<key>pfm_description</key>
+			<string>Suppresses the popup to download additonal sound content on launch. Yes, in fact, 'Download' is spelled 'Dowload' in the preference key.</string>
 			<key>pfm_name</key>
 			<string>DontShowAdditionalContentDowload</string>
+			<key>pfm_title</key>
+			<string>Don't Show Additional Content Download</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-			<key>pfm_title</key>
-			<string>DontShowAdditionalContentDowload</string>
-			<key>pfm_description</key>
-			<string>Suppresses the popup to download additonal sound content on launch.</string>
 		</dict>
-
-        <dict>
-            <key>pfm_name</key>
-            <string>FeatureAvailable_ExpertAudio</string>
-            <key>pfm_type</key>
-            <string>boolean</string>
-            <key>pfm_title</key>
-            <string>Enable Additional Option: Audio</string>
-            <key>pfm_description</key>
-            <string>Enables destructive audio editing, and advanced configuration options for audio editing experts.</string>
-        </dict>
-
-         <dict>
-            <key>pfm_name</key>
-            <string>FeatureAvailable_ExpertCS</string>
-            <key>pfm_type</key>
-            <string>boolean</string>
-            <key>pfm_title</key>
-            <string>Enable Additional Option: Control Surfaces</string>
-            <key>pfm_description</key>
-            <string>Allows experts to create new, and edit any functional detail of existing control surface systems.</string>
-        </dict>
-
-         <dict>
-            <key>pfm_name</key>
-            <string>FeatureAvailable_ExpertEditing</string>
-            <key>pfm_type</key>
-            <string>boolean</string>
-            <key>pfm_title</key>
-            <string>Enable Additional Option: Advanced Editing</string>
-            <key>pfm_description</key>
-            <string>Enables advanced editing functionality, including: aliases, track reassignment, historic tuning scales, and the Tempo Interpreter.</string>
-        </dict>
-
-         <dict>
-            <key>pfm_name</key>
-            <string>FeatureAvailable_ExpertMIDI</string>
-            <key>pfm_type</key>
-            <string>boolean</string>
-            <key>pfm_title</key>
-            <string>Enable Additional Option: MIDI</string>
-            <key>pfm_description</key>
-            <string>Allows signal flow control and real-time processing of MIDI input and output streams in the Environment.</string>
-        </dict>
-        
-        <dict>
-            <key>pfm_name</key>
-            <string>FeatureAvailable_ExpertScore</string>
-            <key>pfm_type</key>
-            <string>boolean</string>
-            <key>pfm_title</key>
-            <string>Enable Additional Option: Score</string>
-            <key>pfm_description</key>
-            <string>Enables the full feature set of the Score window for notation experts.</string>
-        </dict>
-
-        <dict>
-            <key>pfm_name</key>
-            <string>FeatureAvailable_Surround</string>
-            <key>pfm_type</key>
-            <string>boolean</string>
-            <key>pfm_title</key>
-            <string>Enable Additional Option: Surround</string>
-            <key>pfm_description</key>
-            <string>Enables all features for surround audio productions, and requires a surround speaker setup for monitoring.</string>
-        </dict>
-
-        <dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Enables destructive audio editing, and advanced configuration options for audio editing experts.</string>
 			<key>pfm_name</key>
-			<string>RecentWhatsNewPanelVersion</string>
-			<key>pfm_type</key>
-			<string>integer</string>
+			<string>FeatureAvailable_ExpertAudio</string>
 			<key>pfm_title</key>
-			<string>RecentWhatsNewPanelVersion</string>
+			<string>Enable Additional Option: Audio</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Allows experts to create new, and edit any functional detail of existing control surface systems.</string>
+			<key>pfm_name</key>
+			<string>FeatureAvailable_ExpertCS</string>
+			<key>pfm_title</key>
+			<string>Enable Additional Option: Control Surfaces</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Enables advanced editing functionality, including: aliases, track reassignment, historic tuning scales, and the Tempo Interpreter.</string>
+			<key>pfm_name</key>
+			<string>FeatureAvailable_ExpertEditing</string>
+			<key>pfm_title</key>
+			<string>Enable Additional Option: Advanced Editing</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Allows signal flow control and real-time processing of MIDI input and output streams in the Environment.</string>
+			<key>pfm_name</key>
+			<string>FeatureAvailable_ExpertMIDI</string>
+			<key>pfm_title</key>
+			<string>Enable Additional Option: MIDI</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Enables the full feature set of the Score window for notation experts.</string>
+			<key>pfm_name</key>
+			<string>FeatureAvailable_ExpertScore</string>
+			<key>pfm_title</key>
+			<string>Enable Additional Option: Score</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Enables all features for surround audio productions, and requires a surround speaker setup for monitoring.</string>
+			<key>pfm_name</key>
+			<string>FeatureAvailable_Surround</string>
+			<key>pfm_title</key>
+			<string>Enable Additional Option: Surround</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
 			<key>pfm_description</key>
 			<string>Suppresses the What's New window on launch. Correct value for Logic Pro 10.4.3 is 7.</string>
-		</dict>
-
-         <dict>
 			<key>pfm_name</key>
-			<string>userLevel</string>
+			<string>RecentWhatsNewPanelVersion</string>
+			<key>pfm_title</key>
+			<string>RecentWhatsNewPanelVersion</string>
 			<key>pfm_type</key>
 			<string>integer</string>
-			<key>pfm_type_input</key>
-			<string>boolean</string>
-			<key>pfm_title</key>
-			<string>Enable Show Advanced Tools</string>
+		</dict>
+		<dict>
 			<key>pfm_description</key>
 			<string>Configures whether Show Advanced Tools is enabled.</string>
-            <key>pfm_range_list</key>
+			<key>pfm_name</key>
+			<string>userLevel</string>
+			<key>pfm_range_list</key>
 			<array>
 				<integer>0</integer>
 				<integer>10</integer>
 			</array>
-		</dict>
-
-		<dict>
-			<key>pfm_name</key>
-			<string>startupAction</string>
+			<key>pfm_title</key>
+			<string>Enable Show Advanced Tools</string>
 			<key>pfm_type</key>
 			<string>integer</string>
-			<key>pfm_title</key>
-			<string>startupAction</string>
+			<key>pfm_type_input</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
 			<key>pfm_description</key>
 			<string>Configures Logic's startup behaviour.</string>
+			<key>pfm_name</key>
+			<string>startupAction</string>
 			<key>pfm_range_list</key>
 			<array>
 				<integer>0</integer>
 				<integer>1</integer>
 				<integer>2</integer>
-                <integer>3</integer>
-                <integer>4</integer>
-                <integer>5</integer>
-                <integer>6</integer>
+				<integer>3</integer>
+				<integer>4</integer>
+				<integer>5</integer>
+				<integer>6</integer>
 			</array>
-
 			<key>pfm_range_list_titles</key>
 			<array>
 				<string>Do Nothing</string>
 				<string>Open Most Recent Project</string>
 				<string>Open Existing Project</string>
-                <string>Select a Template</string>
-                <string>Create New Empty Project</string>
-                <string>Create New Project Using Default Template</string>
-                <string>Ask</string>
+				<string>Select a Template</string>
+				<string>Create New Empty Project</string>
+				<string>Create New Project Using Default Template</string>
+				<string>Ask</string>
 			</array>
+			<key>pfm_title</key>
+			<string>startupAction</string>
+			<key>pfm_type</key>
+			<string>integer</string>
 		</dict>
-    </array>
+	</array>
+	<key>pfm_targets</key>
+	<array>
+		<string>system</string>
+		<string>user</string>
+	</array>
+	<key>pfm_title</key>
+	<string>Logic Pro X</string>
+	<key>pfm_unique</key>
+	<false/>
+	<key>pfm_version</key>
+	<integer>2</integer>
 </dict>
 </plist>


### PR DESCRIPTION
Fix & extension of #27 PR

- Ran plutil -convert xml1 to organize XML alphabetically
- Removed extraneous blank spaces
- Updated DontShowAdditionalContentDowload description to indicate that download is misspelled
- Update pfm_title for DontShowAdditionalContentDowload