### PR TITLE
Changed payload type and payload identifier for NSExtension

### DIFF
--- a/Manifests/ManifestsApple/com.apple.NSExtension.plist
+++ b/Manifests/ManifestsApple/com.apple.NSExtension.plist
@@ -48,7 +48,7 @@
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<string>com.apple.font</string>
+			<string>com.apple.NSExtension</string>
 			<key>pfm_description</key>
 			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
 			<key>pfm_name</key>
@@ -62,7 +62,7 @@
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<string>com.apple.font</string>
+			<string>com.apple.NSExtension</string>
 			<key>pfm_description</key>
 			<string>The type of the payload, a reverse dns string</string>
 			<key>pfm_name</key>


### PR DESCRIPTION
Noticed that the identifier and payload description were wrong for the Extensions payload.