### PR TITLE
Update com.microsoft.autoupdate2.plist

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-01-16T21:40:50Z</date>
+	<date>2019-03-06T22:41:50Z</date>
 	<key>pfm_subkeys</key>
 	<array>
 		<dict>
@@ -649,6 +649,16 @@
 							<string>all</string>
 							<key>pfm_name</key>
 							<string>Application ID</string>
+							<key>pfm_range_list</key>
+							<array>
+								<string>MSau03</string>
+								<string>MSau04</string>
+							</array>
+							<key>pfm_range_list_titles</key>
+							<array>
+								<string>AutoUpdate 4.6 and below</string>
+								<string>AutoUpdate 4.7 and above</string>
+							</array>
 							<key>pfm_require</key>
 							<string>always</string>
 							<key>pfm_title</key>
@@ -807,6 +817,6 @@
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>7</integer>
+	<integer>8</integer>
 </dict>
 </plist>


### PR DESCRIPTION
Changes needed for the change of the Application ID for Microsoft AutoUpdate from the default MSau03 to MSau04 and the option of MSau03 for previous versions.