### PR TITLE
Fix incorrect title

### DIFF
--- a/Manifests/ManifestsApple/com.apple.SoftwareUpdate.plist
+++ b/Manifests/ManifestsApple/com.apple.SoftwareUpdate.plist
@@ -177,7 +177,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_macos_min</key>
 			<string>10.14</string>
 			<key>pfm_title</key>
-			<string>Automatically install app updates from the App Store</string>
+			<string>Automatically install macOS updates</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
@@ -300,6 +300,6 @@ Availability: Available in macOS 10.14 and later.</string>
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>5</integer>
+	<integer>6</integer>
 </dict>
 </plist>


### PR DESCRIPTION
The key for "Install app updates from the App Store" in 10.14 is in `/Library/Preferences/com.apple.commerce.plist` which doesn't have a manifest yet.