### PR TITLE
Added the EnableNewOutlook key to the Microsoft Outlook manifest

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.microsoft.Outlook.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.Outlook.plist
@@ -776,8 +776,6 @@ You or administrators may want to suppress the initial warning message.</string>
 			<integer>0</integer>
 			<key>pfm_description</key>
 			<string>Lets users on the production channel try out the new Outlook. This key can be used to manage the deployment and default position of the new Outlook switch.</string>
-			<key>pfm_description_reference</key>
-			<string>Lets users on the production channel try out the new Outlook. This key can be used to manage the deployment and default position of the new Outlook switch.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://twitter.com/jeffreykalvass/status/1296500175700205575</string>
 			<key>pfm_name</key>


### PR DESCRIPTION
Saw a tweet from William Smith and Jeffrey Kalvass that this key was added. Haven't found any offical posts form Microsoft so I've added the link to the tweet to the pfm_documentation_url. [link to tweet](https://twitter.com/jeffreykalvass/status/1296500175700205575).

Hope the description is ok, english isn't my first language.

First time trying to attribute by doing a pull request. Please let me know if and what I could have done better.  