### PR TITLE
Outlook manifest update

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.microsoft.Outlook.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.Outlook.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2022-01-30T17:38:16Z</date>
+	<date>2025-10-13T09:08:01Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -340,6 +340,22 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<string>DisableSignatures</string>
 			<key>pfm_title</key>
 			<string>Disable Signatures</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>16.92</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Prevent Outlook from being able to use the default signature. This will keep the default Outlook signature but disable the settings to apply the default Outlook signatures for new messages and for reply/forward message settings.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://learn.microsoft.com/en-us/microsoft-365-apps/mac/preferences-outlook#disable-default-signature</string>
+			<key>pfm_name</key>
+			<string>DisableDefaultAppSignature</string>
+			<key>pfm_title</key>
+			<string>Disable Default Signature</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
@@ -828,6 +844,6 @@ You or administrators may want to suppress the initial warning message.</string>
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>7</integer>
+	<integer>8</integer>
 </dict>
 </plist>


### PR DESCRIPTION
This PR adds the `DisableDefaultAppSignature` key to the Outlook manifest.