### PR TITLE
Google Chrome - Add new LocalNetworkAccess keys for v.140

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.google.Chrome.plist
+++ b/Manifests/ManagedPreferencesApplications/com.google.Chrome.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2025-01-15T16:36:56Z</date>
+	<date>2025-10-14T00:00:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -148,6 +148,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 				<string>Google Cast</string>
 				<string>HTTP Authentication</string>
 				<string>Legacy Browser Support</string>
+				<string>Local Network Access</string>
 				<string>Misc.</string>
 				<string>Native Messaging</string>
 				<string>Password Manager</string>
@@ -268,6 +269,12 @@ During a profile replacement, the system updates payloads with the same 'Payload
 					<string>BrowserSwitcherKeepLastChromeTab</string>
 					<string>BrowserSwitcherUrlGreylist</string>
 					<string>BrowserSwitcherUrlList</string>
+				</array>
+				<key>Local Network Access</key>
+				<array>
+					<string>LocalNetworkAccessAllowedForUrls</string>
+					<string>LocalNetworkAccessBlockedForUrls</string>
+					<string>LocalNetworkAccessRestrictionsEnabled</string>
 				</array>
 				<key>Misc.</key>
 				<array>
@@ -3380,6 +3387,74 @@ If this policy is left not set, 2 will be used.</string>
 			<string>Ads setting for sites with intrusive ads</string>
 			<key>pfm_type</key>
 			<string>integer</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>138</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>A policy to control whether users are prompted to allow sites to ask for Local Network Access.</string>
+			<key>pfm_description_reference</key>
+			<string>When this policy is set to Enabled, any time when a warning is supposed to be displayed in Chrome DevTools due to Local Network Access checks failing, the main request will be blocked instead.
+When this policy is set to Disabled or unset, Local Network Access requests will use the default handling of these requests.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://chromeenterprise.google/policies/#LocalNetworkAccessRestrictionsEnabled</string>
+			<key>pfm_name</key>
+			<string>LocalNetworkAccessRestrictionsEnabled</string>
+			<key>pfm_title</key>
+			<string>Local Network Access Restrictions Enabled</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>139</string>
+			<key>pfm_description</key>
+			<string>A policy to automatically grant specific sites Local Network Access.</string>
+			<key>pfm_description_reference</key>
+			<string>List of URL patterns. Requests initiated from websites served by matching origins are not subject to Local Network Access checks.
+If an origin is covered by both this policy and by LocalNetworkAccessBlockedForUrls, LocalNetworkAccessBlockedForUrls takes precedence.
+For origins not covered by the patterns specified here, the user's personal configuration will apply. </string>
+			<key>pfm_documentation_url</key>
+			<string>https://chromeenterprise.google/policies/#LocalNetworkAccessAllowedForUrls</string>
+			<key>pfm_name</key>
+			<string>LocalNetworkAccessAllowedForUrls</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+			</array>
+			<key>pfm_title</key>
+			<string>Local Network Access Allowed For URLs</string>
+			<key>pfm_type</key>
+			<string>array</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>139</string>
+			<key>pfm_description</key>
+			<string>A policy to automatically deny specific sites Local Network Access.</string>
+			<key>pfm_description_reference</key>
+			<string>List of URL patterns. Requests initiated from websites served by matching origins are blocked from issuing Local Network Access requests.
+If an origin is covered by both this policy and by LocalNetworkAccessAllowedForUrls, this policy takes precedence.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://chromeenterprise.google/policies/#LocalNetworkAccessBlockedForUrls</string>
+			<key>pfm_name</key>
+			<string>LocalNetworkAccessBlockedForUrls</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+			</array>
+			<key>pfm_title</key>
+			<string>Local Network Access Blocked For URLs</string>
+			<key>pfm_type</key>
+			<string>array</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
@@ -10151,6 +10226,6 @@ If the policy DeveloperToolsAvailability is set, the value of the policy Develop
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>16</integer>
+	<integer>17</integer>
 </dict>
 </plist>


### PR DESCRIPTION
Google has added new Chrome policy keys for a LocalNetworkAccess privacy control.
https://developer.chrome.com/blog/local-network-access

https://chromeenterprise.google/policies/#LocalNetworkAccessSettings

I've tested that these work by using this guide from Box.com: https://support.box.com/hc/en-us/articles/45163820905107-Allow-Box-domains-local-network-access-in-Chromium-142-to-avoid-Box-Tools-disruption?id=&utm_buid=&utm_content=chromium142&utm_medium=Email&utm_source=iterable&utm_theme=CloudContentManagement#

<img width="1498" height="851" alt="image" src="https://github.com/user-attachments/assets/54090ce0-a246-4acb-ae7b-daa4fd641665" />

I'm still a bit confused about how the categories work, I think these are getting shoved into "Other" because of the default `Process custom manifests for optimal display in iMazing Profile Editor (recommended)` setting, when I turn that off I see the new "LocalNetworkAccess" tab I created. I didn't see a better category to add these to.