### PR TITLE
feat(dev.firezone.firezone): add hideResourceList key

### DIFF
--- a/Manifests/ManagedPreferencesApplications/dev.firezone.firezone.plist
+++ b/Manifests/ManagedPreferencesApplications/dev.firezone.firezone.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2025-05-26T15:53:00Z</date>
+	<date>2025-11-19T18:29:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -253,6 +253,6 @@ A profile can consist of payloads with different version numbers. For example, c
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>1</integer>
+	<integer>2</integer>
 </dict>
 </plist>


### PR DESCRIPTION
Adds a newly-supported `hideResourceList` configuration option which, like its sibling `hideAdminPortalMenuItem`, hides the resource list in the menubar (macOS) or session view (iOS) accordingly.