### PR TITLE
URL Correction

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.microsoft.SkypeForBusiness.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.SkypeForBusiness.plist
@@ -7,13 +7,13 @@
 	<key>pfm_description</key>
 	<string>Skype for Business settings</string>
 	<key>pfm_documentation_url</key>
-	<string>https://docs.microsoft.com/en-us/skypeforbusiness/deploy/deploy-clients/customize-the-mac-client-experience / https://techcommunity.microsoft.com/t5/Skype-for-Business-IT-Pro/Skype-for-Business-Mac-client-Preference-Settings/m-p/66530</string>
+	<string>https://docs.microsoft.com/en-us/skypeforbusiness/deploy/deploy-clients/customize-the-mac-client-experience</string>
 	<key>pfm_domain</key>
 	<string>com.microsoft.SkypeForBusiness</string>
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2025-11-21T08:19:59Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>


### PR DESCRIPTION
Two URLs cannot be supported in `pfm_documentation_url` so one had to go in the Skype for Business manifest.