### PR TITLE
Add CurrentThrottle to ChannelName pfm_range_list

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2024-12-16T19:42:12Z</date>
+	<date>2025-11-30T12:00:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -230,6 +230,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<array>
 				<string>Production</string>
 				<string>Current</string>
+				<string>CurrentThrottle</string>
 				<string>External</string>
 				<string>Preview</string>
 				<string>InsiderFast</string>
@@ -240,6 +241,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<array>
 				<string>Production (pre MAU 4.29)</string>
 				<string>Current (MAU 4.29+)</string>
+				<string>CurrentThrottle - Current channel without weekly Outlook updates (MAU 4.29+)</string>
 				<string>Office Insider Slow: "External" (pre MAU 4.29)</string>
 				<string>Preview (MAU 4.29+)</string>
 				<string>Office Insider Fast: "InsiderFast" (pre MAU 4.29)</string>
@@ -2549,6 +2551,6 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>18</integer>
+	<integer>19</integer>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

Adds `CurrentThrottle` as a valid value for the `ChannelName` preference in the Microsoft AutoUpdate (MAU) manifest.

## Background

`CurrentThrottle` is a documented MAU channel that provides Current channel updates but **skips weekly Outlook releases**. This is useful for organisations that want stable monthly releases for Outlook whilst still receiving regular updates for other Office apps.

## Documentation

Microsoft documents this channel at:
- https://learn.microsoft.com/en-us/microsoft-365-apps/mac/mau-preferences

Relevant quote:
> **CurrentThrottle** – Created to allow people to skip "weekly" Outlook releases in Current channel. Other apps are updated through Current channel (default).

## Changes

- Added `CurrentThrottle` to `pfm_range_list` (after `Current`)
- Added corresponding title: `"CurrentThrottle - Current channel without weekly Outlook updates (MAU 4.29+)"`
- Updated `pfm_last_modified` to 2025-11-30
- Bumped `pfm_version` from 18 to 19

## Testing

Pre-commit hooks passed (`Check Apple Preference Manifests`).

## Related

This value is actively used in production by [OpenIntuneBaseline](https://github.com/SkipToTheEndpoint/OpenIntuneBaseline) MAU profiles.