### PR TITLE
Update Microsoft AutoUpdate manifest: add CurrentThrottle and GuardAgainstAppModification

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2024-12-16T19:42:12Z</date>
+	<date>2025-11-30T12:00:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -230,6 +230,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<array>
 				<string>Production</string>
 				<string>Current</string>
+				<string>CurrentThrottle</string>
 				<string>External</string>
 				<string>Preview</string>
 				<string>InsiderFast</string>
@@ -240,6 +241,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<array>
 				<string>Production (pre MAU 4.29)</string>
 				<string>Current (MAU 4.29+)</string>
+				<string>CurrentThrottle - Current channel without weekly Outlook updates (MAU 4.29+)</string>
 				<string>Office Insider Slow: "External" (pre MAU 4.29)</string>
 				<string>Preview (MAU 4.29+)</string>
 				<string>Office Insider Fast: "InsiderFast" (pre MAU 4.29)</string>
@@ -2549,6 +2551,6 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>18</integer>
+	<integer>19</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
@@ -305,6 +305,20 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Keeps a clone of an application in a cache location. This helps prevent update failures caused by security software that modifies installed applications.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://learn.microsoft.com/en-us/microsoft-365-apps/mac/mau-preferences</string>
+			<key>pfm_name</key>
+			<string>GuardAgainstAppModification</string>
+			<key>pfm_title</key>
+			<string>Guard Against App Modification</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
 			<key>pfm_app_min</key>
 			<string>3.8</string>
 			<key>pfm_default</key>


### PR DESCRIPTION
## Summary

Updates the Microsoft AutoUpdate (`com.microsoft.autoupdate2`) manifest with a missing preference key and a missing channel value that are documented by Microsoft but not currently in the schema.

## Changes

### 1. Add `CurrentThrottle` to ChannelName pfm_range_list

`CurrentThrottle` is a documented MAU channel value that provides Current channel updates but **skips weekly Outlook releases**. This is useful for organisations that want stable monthly releases for Outlook whilst still receiving regular updates for other Office apps.

**Documentation**: https://learn.microsoft.com/en-us/microsoft-365-apps/mac/mau-preferences

> **CurrentThrottle** – Created to allow people to skip "weekly" Outlook releases in Current channel. Other apps are updated through Current channel (default).

### 2. Add `GuardAgainstAppModification` preference key

`GuardAgainstAppModification` is a new boolean preference that keeps a clone of an application in a cache location. This helps prevent update failures caused by security software that modifies installed applications.

**Documentation**: https://learn.microsoft.com/en-us/microsoft-365-apps/mac/mau-preferences

> **GuardAgainstAppModification** – Setting this preference to TRUE keeps a clone of an application in cache location always.

## Metadata Updates

- Updated `pfm_last_modified` to 2025-11-30
- Bumped `pfm_version` from 18 to 19

## Testing

Pre-commit hooks passed (`Check Apple Preference Manifests`).

## Related

Both preferences are actively used in production by [OpenIntuneBaseline](https://github.com/SkipToTheEndpoint/OpenIntuneBaseline) MAU profiles.