### PR TITLE
com.okta.mobile: add OktaVerify.Plugins and update DeviceHealthOptions

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.okta.mobile.plist
+++ b/Manifests/ManagedPreferencesApplications/com.okta.mobile.plist
@@ -65,7 +65,7 @@
 	ChiYvHgSithnzR++s9bEkCFDhgwZMuR8+TcgDLDRAr0H4wAAAABJRU5ErkJggg==
 	</data>
 	<key>pfm_last_modified</key>
-	<date>2025-12-18T22:30:02Z</date>
+	<date>2026-02-20T18:00:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -174,14 +174,15 @@
 			<key>pfm_name</key>
 			<string>OktaVerify.DeviceHealthOptions</string>
 			<key>pfm_note</key>
-			<string>By default (when no values are set), all device health checks are displayed in Okta Verify on user devices. 
-If the value contains 'Disabled', the Device Health page isn't displayed in Okta Verify</string>
+			<string>By default (when no values are set), all device health checks are displayed in Okta Verify on user devices.
+If the value contains 'Disabled', the Device Health page isn't displayed in Okta Verify.
+Supported values (semicolon-separated): Disabled, HideOSUpdate, HideDiskEncryption, HideBiometrics, HidePassword</string>
 			<key>pfm_title</key>
 			<string>Device Health Options</string>
 			<key>pfm_type</key>
 			<string>string</string>
 			<key>pfm_value_placeholder</key>
-			<string>HideDiskEncryption;HideBiometrics</string>
+			<string>HideOSUpdate;HideDiskEncryption;HideBiometrics;HidePassword</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
@@ -319,6 +320,31 @@ If the value contains 'Disabled', the Device Health page isn't displayed in Okta
 			<key>pfm_value_placeholder</key>
 			<string>my-test-domain.oktapreview.com;my-prod-domain.oktapreview.com</string>
 		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Enable Okta Verify to collect trust signals from an EDR client that's running on the same macOS device</string>
+			<key>pfm_documentation_url</key>
+			<string>https://help.okta.com/oie/en-us/content/topics/identity-engine/devices/managed-app-configs-macos.htm#OktaVeri4</string>
+			<key>pfm_name</key>
+			<string>OktaVerify.Plugins</string>
+			<key>pfm_note</key>
+			<string>Specify EDR client bundle identifiers to enable endpoint security integration plugins. See Manage endpoint security integration plugins for macOS.</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_description</key>
+					<string>The EDR client bundle identifier</string>
+					<key>pfm_type</key>
+					<string>string</string>
+					<key>pfm_value_placeholder</key>
+					<string>com.crowdstrike.zta</string>
+				</dict>
+			</array>
+			<key>pfm_title</key>
+			<string>Plugins</string>
+			<key>pfm_type</key>
+			<string>array</string>
+		</dict>
 	</array>
 	<key>pfm_targets</key>
 	<array>
@@ -329,6 +355,6 @@ If the value contains 'Disabled', the Device Health page isn't displayed in Okta
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>3</integer>
+	<integer>4</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/com.okta.mobile.plist
+++ b/Manifests/ManagedPreferencesApplications/com.okta.mobile.plist
@@ -65,7 +65,7 @@
 	ChiYvHgSithnzR++s9bEkCFDhgwZMuR8+TcgDLDRAr0H4wAAAABJRU5ErkJggg==
 	</data>
 	<key>pfm_last_modified</key>
-	<date>2026-02-20T18:00:00Z</date>
+	<date>2026-02-23T19:02:40Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -328,16 +328,75 @@ Supported values (semicolon-separated): Disabled, HideOSUpdate, HideDiskEncrypti
 			<key>pfm_name</key>
 			<string>OktaVerify.Plugins</string>
 			<key>pfm_note</key>
-			<string>Specify EDR client bundle identifiers to enable endpoint security integration plugins. See Manage endpoint security integration plugins for macOS.</string>
+			<string>Specify EDR client configurations to enable endpoint security integration plugins. See Manage endpoint security integration plugins for macOS.</string>
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>
-					<key>pfm_description</key>
-					<string>The EDR client bundle identifier</string>
+					<key>pfm_subkeys</key>
+					<array>
+						<dict>
+							<key>pfm_description</key>
+							<string>The EDR client bundle identifier</string>
+							<key>pfm_name</key>
+							<string>name</string>
+							<key>pfm_title</key>
+							<string>Name</string>
+							<key>pfm_type</key>
+							<string>string</string>
+							<key>pfm_value_placeholder</key>
+							<string>com.crowdstrike.zta</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>Description of the EDR integration</string>
+							<key>pfm_name</key>
+							<string>description</string>
+							<key>pfm_title</key>
+							<string>Description</string>
+							<key>pfm_type</key>
+							<string>string</string>
+							<key>pfm_value_placeholder</key>
+							<string>File-based EDR integration between Okta Verify and the CrowdStrike Falcon agent</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>The integration type (FILE for file-based integrations)</string>
+							<key>pfm_name</key>
+							<string>type</string>
+							<key>pfm_title</key>
+							<string>Type</string>
+							<key>pfm_type</key>
+							<string>string</string>
+							<key>pfm_value_placeholder</key>
+							<string>FILE</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>The data format used by the EDR client (e.g., JWT)</string>
+							<key>pfm_name</key>
+							<string>format</string>
+							<key>pfm_title</key>
+							<string>Format</string>
+							<key>pfm_type</key>
+							<string>string</string>
+							<key>pfm_value_placeholder</key>
+							<string>JWT</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>The file path where the EDR client writes security posture data</string>
+							<key>pfm_name</key>
+							<string>location</string>
+							<key>pfm_title</key>
+							<string>Location</string>
+							<key>pfm_type</key>
+							<string>string</string>
+							<key>pfm_value_placeholder</key>
+							<string>/Library/Application Support/Crowdstrike/ZeroTrustAssessment/data.zta</string>
+						</dict>
+					</array>
 					<key>pfm_type</key>
-					<string>string</string>
-					<key>pfm_value_placeholder</key>
-					<string>com.crowdstrike.zta</string>
+					<string>dictionary</string>
 				</dict>
 			</array>
 			<key>pfm_title</key>


### PR DESCRIPTION
Closes #869

### Changes

- **Add `OktaVerify.Plugins`** (Array) — enables EDR client integration (e.g., CrowdStrike ZTA). Documented by Okta but missing from the manifest.
- **Update `OktaVerify.DeviceHealthOptions`** — note and placeholder now list all documented values: `Disabled`, `HideOSUpdate`, `HideDiskEncryption`, `HideBiometrics`, `HidePassword` (previously only showed 2 of 5).
- Bump `pfm_version` to 4, update `pfm_last_modified`.

### Reference

https://help.okta.com/oie/en-us/content/topics/identity-engine/devices/managed-app-configs-macos.htm