### PR TITLE
Update com.okta.mobile: add OktaVerify.Plugins key and update DeviceHealthOptions

### DIFF
--- a/Icons/index
+++ b/Icons/index
@@ -1580,6 +1580,6 @@
 		</dict>
 	</dict>
 	<key>date</key>
-	<date>2026-03-09T10:15:46Z</date>
+	<date>2026-03-22T18:02:03Z</date>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/com.okta.mobile.plist
+++ b/Manifests/ManagedPreferencesApplications/com.okta.mobile.plist
@@ -65,7 +65,7 @@
 	ChiYvHgSithnzR++s9bEkCFDhgwZMuR8+TcgDLDRAr0H4wAAAABJRU5ErkJggg==
 	</data>
 	<key>pfm_last_modified</key>
-	<date>2025-12-18T22:30:02Z</date>
+	<date>2026-03-22T18:01:52Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -181,7 +181,7 @@ If the value contains 'Disabled', the Device Health page isn't displayed in Okta
 			<key>pfm_type</key>
 			<string>string</string>
 			<key>pfm_value_placeholder</key>
-			<string>HideDiskEncryption;HideBiometrics</string>
+			<string>HideDiskEncryption;HideBiometrics;HideOSUpdate;HidePassword</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
@@ -318,6 +318,29 @@ If the value contains 'Disabled', the Device Health page isn't displayed in Okta
 			<string>string</string>
 			<key>pfm_value_placeholder</key>
 			<string>my-test-domain.oktapreview.com;my-prod-domain.oktapreview.com</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Enables EDR client integration (e.g., CrowdStrike ZTA)</string>
+			<key>pfm_documentation_url</key>
+			<string>https://help.okta.com/oie/en-us/content/topics/identity-engine/devices/managed-app-configs-macos.htm</string>
+			<key>pfm_name</key>
+			<string>OktaVerify.Plugins</string>
+			<key>pfm_title</key>
+			<string>Plugins</string>
+			<key>pfm_type</key>
+			<string>array</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_title</key>
+					<string>Plugin</string>
+					<key>pfm_type</key>
+					<string>string</string>
+					<key>pfm_value_placeholder</key>
+					<string>com.crowdstrike.zta</string>
+				</dict>
+			</array>
 		</dict>
 	</array>
 	<key>pfm_targets</key>

--- a/Manifests/index
+++ b/Manifests/index
@@ -928,7 +928,7 @@
 		<key>com.okta.mobile</key>
 		<dict>
 			<key>modified</key>
-			<date>2025-12-18T22:30:02Z</date>
+			<date>2026-03-22T18:01:52Z</date>
 			<key>path</key>
 			<string>Manifests/ManagedPreferencesApplications/com.okta.mobile.plist</string>
 			<key>version</key>
@@ -2454,6 +2454,6 @@
 		</dict>
 	</dict>
 	<key>date</key>
-	<date>2026-03-09T10:15:46Z</date>
+	<date>2026-03-22T18:02:03Z</date>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
Adds `OktaVerify.Plugins` and updates `OktaVerify.DeviceHealthOptions` to include missing documented values.

## Problem
Closes #869

## Solution
- `OktaVerify.Plugins` (Array type) is documented by Okta but was missing from the manifest. It enables EDR client integration (e.g., CrowdStrike ZTA).
- `OktaVerify.DeviceHealthOptions` note/placeholder was missing some documented values: `HideOSUpdate` and `HidePassword`.
- Regenerated indexes using `updateIndexes.py`.

## Testing
- Verified plist structure
- Ran index updater without errors

---
*This PR was created with AI assistance.*