### PR TITLE
Update 1Password8 Manifest: authentication.defaultDomain / authentication.enforceDomain

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
+++ b/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
@@ -192,7 +192,6 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<string>boolean</string>
 		</dict>
 		<dict>
-			
 			<key>pfm_description</key>
 			<string>Set the default sign-in address for the 1Password app. Users will be prompted to sign in to this account by default.</string>
 			<key>pfm_documentation_url</key>

--- a/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
+++ b/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
@@ -127,6 +127,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<string>PFC_SegmentedControl_0</string>
 			<key>pfm_range_list_titles</key>
 			<array>
+				<string>Authentication</string>
 				<string>General</string>
 				<string>Privacy</string>
 				<string>Security</string>
@@ -136,6 +137,11 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<string>always</string>
 			<key>pfm_segments</key>
 			<dict>
+				<key>Authentication</key>
+				<array>
+					<string>authentication.defaultDomain</string>
+					<string>authentication.enforceDomain</string>
+				</array>
 				<key>General</key>
 				<array>
 					<string>app.startAtLogin</string>
@@ -182,6 +188,40 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<string>app.startAtLogin</string>
 			<key>pfm_title</key>
 			<string>Start at Login</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>domain.1password.com</string>
+			<key>pfm_description</key>
+			<string>Set the default sign-in address for the 1Password app. Users will be prompted to sign in to this account by default.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.1password.com/mobile-device-management/?mac#authentication-opm8</string>
+			<key>pfm_format</key>
+			<string>^[a-zA-Z0-9.-]+\.1password\.(com|ca|eu)$</string>
+			<key>pfm_name</key>
+			<string>authentication.defaultDomain</string>
+			<key>pfm_note</key>
+			<string>Use the format: domain.1password.com. Do not include https:// or trailing slashes.</string>
+			<key>pfm_title</key>
+			<string>Default Sign-in Address</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>When enabled, users cannot change the sign-in address from the default value set in authentication.defaultDomain.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.1password.com/mobile-device-management/?mac#authentication-opm8</string>
+			<key>pfm_name</key>
+			<string>authentication.enforceDomain</string>
+			<key>pfm_note</key>
+			<string>This setting only takes effect when authentication.defaultDomain is configured. If the default domain is empty, this setting is ignored.</string>
+			<key>pfm_title</key>
+			<string>Enforce Default Sign-in Address</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>

--- a/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
+++ b/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
@@ -15,7 +15,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2026-04-22T04:50:37Z</date>
+	<date>2026-04-29T08:21:26Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -214,6 +214,20 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<string>When enabled, users cannot change the sign-in address from the default value set in authentication.defaultDomain.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.1password.com/mobile-device-management/?mac#authentication-opm8</string>
+			<key>pfm_exclude</key>
+			<array>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_present</key>
+							<false/>
+							<key>pfm_target</key>
+							<string>authentication.defaultDomain</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
 			<key>pfm_name</key>
 			<string>authentication.enforceDomain</string>
 			<key>pfm_note</key>

--- a/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
+++ b/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
@@ -192,8 +192,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_default</key>
-			<string>domain.1password.com</string>
+			
 			<key>pfm_description</key>
 			<string>Set the default sign-in address for the 1Password app. Users will be prompted to sign in to this account by default.</string>
 			<key>pfm_documentation_url</key>
@@ -208,6 +207,8 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<string>Default Sign-in Address</string>
 			<key>pfm_type</key>
 			<string>string</string>
+			<key>pfm_value_placeholder</key>
+			<string>domain.1password.com</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>

--- a/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
+++ b/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
@@ -15,7 +15,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2024-12-20T13:41:48Z</date>
+	<date>2026-04-22T04:50:37Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -495,6 +495,6 @@ During a profile replacement, the system updates payloads with the same 'Payload
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>3</integer>
+	<integer>4</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
+++ b/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
@@ -211,8 +211,6 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<string>domain.1password.com</string>
 		</dict>
 		<dict>
-			<key>pfm_default</key>
-			<false/>
 			<key>pfm_description</key>
 			<string>When enabled, users cannot change the sign-in address from the default value set in authentication.defaultDomain.</string>
 			<key>pfm_documentation_url</key>


### PR DESCRIPTION
Related: https://github.com/ProfileManifests/ProfileManifests/issues/862

Tested in ProfileCreator 0.3.7