### PR TITLE
Manifest Formatting Cleanup

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.pratikkumar.airserver-mac.plist
+++ b/Manifests/ManagedPreferencesApplications/com.pratikkumar.airserver-mac.plist
@@ -322,10 +322,10 @@ A profile can consist of payloads with different version numbers. For example, c
 			</array>
 			<key>pfm_name</key>
 			<string>UserLosslessAudioReceiverName</string>
-			<key>pfm_type</key>
-			<string>string</string>
 			<key>pfm_title</key>
 			<string>User-Visible Lossless Recevier Device Name</string>
+			<key>pfm_type</key>
+			<string>string</string>
 			<key>pfm_value_placeholder</key>
 			<string>Lossless Quality Receiver Name</string>
 		</dict>

--- a/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.plist
+++ b/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.plist
@@ -132,7 +132,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.52</string>
 			<key>pfm_description</key>
 			<string>Specifies the name of the organization managing Tailscale, for instance “XYZ Corp, Inc.”. The value will be displayed in the Tailscale client, so that users can easily reach your internal support resources.</string>
@@ -148,7 +148,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>XYZ Corp, Inc.</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.52</string>
 			<key>pfm_description</key>
 			<string>Specifies a caption to be displayed in the Managed By view in the Tailscale client. Use this string value to provide your users with information on how to reach support resources for Tailscale in your organization.</string>
@@ -164,7 +164,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Support is available on the #tailscale channel on the company Slack.</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.52</string>
 			<key>pfm_description</key>
 			<string>Specifies a URL pointing to a help desk webpage, or other helpful resources for users in the organization. Clicking the Support button in the Tailscale UI will open this webpage.</string>
@@ -180,7 +180,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>https://www.xyz-corp-example.com/helpdesk</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.46</string>
 			<key>pfm_description</key>
 			<string>The first time the application is opened on a Mac, Tailscale installs a macOS login helper. This allows Tailscale to start automatically when the user logs into their account. This boolean controls whether the login helper should start Tailscale at login time.</string>
@@ -194,7 +194,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>boolean</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.52</string>
 			<key>pfm_description</key>
 			<string>When set to true, this boolean instructs Tailscale to always be connected and actively monitor the tunnel state for disconnections. The Disconnect toggle will be disabled, to prevent users from disabling the VPN themselves. An attempt to disconnect will present a banner informing the user the organization’s policy prevents Tailscale from being disconnected. If the client detects the VPN tunnel is down because the Tailscale VPN process was terminated, Tailscale will automatically restart it and reconnect. You might want to use this policy together with an always-on VPN configuration profile.</string>
@@ -207,22 +207,22 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
-        <dict>
-            <key>pfm_app_min</key>
-            <string>1.68</string>
-            <key>pfm_description</key>
-            <string>By default, Tailscale v1.68 and later detect when DHCP Option 121 is being used, and the client will display a warning to the user in the UI when usage of this option is detected. You may set the HideDHCP121Warnings system policy to true to hide such warnings if you have a legitimate need to use Option 121.</string>
-            <key>pfm_documentation_url</key>
-            <string>https://tailscale.com/kb/1315/mdm-keys#suppress-dhcp-option-121-warnings</string>
-            <key>pfm_name</key>
-            <string>HideDHCP121Warnings</string>
-            <key>pfm_title</key>
-            <string>Suppress DHCP Option 121 warnings</string>
-            <key>pfm_type</key>
-            <string>boolean</string>
-        </dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
+			<string>1.68</string>
+			<key>pfm_description</key>
+			<string>By default, Tailscale v1.68 and later detect when DHCP Option 121 is being used, and the client will display a warning to the user in the UI when usage of this option is detected. You may set the HideDHCP121Warnings system policy to true to hide such warnings if you have a legitimate need to use Option 121.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://tailscale.com/kb/1315/mdm-keys#suppress-dhcp-option-121-warnings</string>
+			<key>pfm_name</key>
+			<string>HideDHCP121Warnings</string>
+			<key>pfm_title</key>
+			<string>Suppress DHCP Option 121 warnings</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
 			<string>1.52</string>
 			<key>pfm_description</key>
 			<string>Specify a tailnet, and its identity provider will be used on the login page. If the policy value is prefixed with "required:"", Tailscale will force that identity provider to be used and won’t allow logging in with anything else.</string>
@@ -238,7 +238,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>required:example.com</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.38.1</string>
 			<key>pfm_description</key>
 			<string>The LoginURL policy can be used to specify a custom control server URL. This should not be changed unless you are not using the standard Tailscale server. Use this policy if you’re deploying your own server, such as Headscale.</string>
@@ -338,7 +338,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.80</string>
 			<key>pfm_description</key>
 			<string>The Hostname policy allows IT administrators to override the hostname configured in the operating system and reported to the coordination server. This can be particularly useful on mobile devices, where the hostname provided by the operating system usually only contains the device's manufacturer name and model.</string>
@@ -438,7 +438,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.50</string>
 			<key>pfm_default</key>
 			<string>show</string>
@@ -464,7 +464,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.52</string>
 			<key>pfm_default</key>
 			<string>show</string>
@@ -490,7 +490,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.50</string>
 			<key>pfm_default</key>
 			<string>show</string>
@@ -516,7 +516,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.50</string>
 			<key>pfm_default</key>
 			<string>show</string>
@@ -542,7 +542,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.50</string>
 			<key>pfm_default</key>
 			<string>show</string>
@@ -568,7 +568,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.50</string>
 			<key>pfm_default</key>
 			<string>show</string>
@@ -620,7 +620,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.52</string>
 			<key>pfm_description</key>
 			<string>Can be used to hide one or more categories of network devices normally displayed in the Tailscale client. Administrators can choose to hide: devices owned by the current user; devices owned by other users; tagged devices. If all three options are chosen, the "Network Devices" menu item disappears entirely and users aren’t able to see any device on the tailnet.</string>
@@ -653,7 +653,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>array</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.50</string>
 			<key>pfm_description</key>
 			<string>When you use the Tailscale menu bar item to copy to the Clipboard the IP address of a device, a notification displaying the IP address is presented. Use this to suppress this Copied IP address to clipboard notification.</string>
@@ -666,20 +666,18 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
-        <dict>
+		<dict>
 			<key>pfm_app_min</key>
 			<string>1.68</string>
-            <key>pfm_default</key>
-            <string>hide</string>
+			<key>pfm_default</key>
+			<string>hide</string>
 			<key>pfm_description</key>
 			<string>When set to hide, the user will not be able to install the CLI helper, and will instead be told to contact their administrator.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://tailscale.com/kb/1315/mdm-keys#hide-the-cli-integration-installer</string>
 			<key>pfm_name</key>
 			<string>CLIIntegration</string>
-			<key>pfm_title</key>
-			<string>Hide the CLI integration installer</string>
-            <key>pfm_range_list</key>
+			<key>pfm_range_list</key>
 			<array>
 				<string>show</string>
 				<string>hide</string>
@@ -689,11 +687,13 @@ A profile can consist of payloads with different version numbers. For example, c
 				<string>Show</string>
 				<string>Hide</string>
 			</array>
+			<key>pfm_title</key>
+			<string>Hide the CLI integration installer</string>
 			<key>pfm_type</key>
 			<string>string</string>
-        </dict>
+		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.46</string>
 			<key>pfm_description</key>
 			<string>When you start Tailscale on your Mac for the first time, an onboarding flow is presented. It explains the Tailscale privacy policy, and guides the user in setting up the VPN configuration on their Mac. You might want to disable this onboarding flow if you are going to automatically set up the VPN configuration on the system by using a configuration profile. In order to do so, this boolean suppresses the onboarding flow when Tailscale launches for the first time and the value is set to true.</string>

--- a/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
+++ b/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
@@ -132,7 +132,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.52</string>
 			<key>pfm_description</key>
 			<string>Specifies the name of the organization managing Tailscale, for instance “XYZ Corp, Inc.”. The value will be displayed in the Tailscale client, so that users can easily reach your internal support resources.</string>
@@ -148,7 +148,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>XYZ Corp, Inc.</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.52</string>
 			<key>pfm_description</key>
 			<string>Specifies a caption to be displayed in the Managed By view in the Tailscale client. Use this string value to provide your users with information on how to reach support resources for Tailscale in your organization.</string>
@@ -164,7 +164,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Support is available on the #tailscale channel on the company Slack.</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.52</string>
 			<key>pfm_description</key>
 			<string>Specifies a URL pointing to a help desk webpage, or other helpful resources for users in the organization. Clicking the Support button in the Tailscale UI will open this webpage.</string>
@@ -194,7 +194,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>boolean</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.52</string>
 			<key>pfm_description</key>
 			<string>If you are using the Standalone version of Tailscale for macOS, the client can also install updates automatically. This feature also relies on the Sparkle framework. We recommend that you always turn this feature on, in order to ensure your users receive any security updates in a timely manner. However, if you manually manage updates, or prefer your users to be notified but to manually update, you can disable the automatic installation. When set to false, the standalone variant of Tailscale for macOS will require user input before updates are installed.</string>
@@ -208,7 +208,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>boolean</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.52</string>
 			<key>pfm_default</key>
 			<string>show</string>
@@ -262,7 +262,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.46</string>
 			<key>pfm_description</key>
 			<string>The first time the application is opened on a Mac, Tailscale installs a macOS login helper. This allows Tailscale to start automatically when the user logs into their account. This boolean controls whether the login helper should start Tailscale at login time.</string>
@@ -276,7 +276,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>boolean</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.52</string>
 			<key>pfm_description</key>
 			<string>When set to true, this boolean instructs Tailscale to always be connected and actively monitor the tunnel state for disconnections. The Disconnect toggle will be disabled, to prevent users from disabling the VPN themselves. An attempt to disconnect will present a banner informing the user the organization’s policy prevents Tailscale from being disconnected. If the client detects the VPN tunnel is down because the Tailscale VPN process was terminated, Tailscale will automatically restart it and reconnect. You might want to use this policy together with an always-on VPN configuration profile.</string>
@@ -289,22 +289,22 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
-        <dict>
-            <key>pfm_app_min</key>
-            <string>1.68</string>
-            <key>pfm_description</key>
-            <string>By default, Tailscale v1.68 and later detect when DHCP Option 121 is being used, and the client will display a warning to the user in the UI when usage of this option is detected. You may set the HideDHCP121Warnings system policy to true to hide such warnings if you have a legitimate need to use Option 121.</string>
-            <key>pfm_documentation_url</key>
-            <string>https://tailscale.com/kb/1315/mdm-keys#suppress-dhcp-option-121-warnings</string>
-            <key>pfm_name</key>
-            <string>HideDHCP121Warnings</string>
-            <key>pfm_title</key>
-            <string>Suppress DHCP Option 121 warnings</string>
-            <key>pfm_type</key>
-            <string>boolean</string>
-        </dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
+			<string>1.68</string>
+			<key>pfm_description</key>
+			<string>By default, Tailscale v1.68 and later detect when DHCP Option 121 is being used, and the client will display a warning to the user in the UI when usage of this option is detected. You may set the HideDHCP121Warnings system policy to true to hide such warnings if you have a legitimate need to use Option 121.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://tailscale.com/kb/1315/mdm-keys#suppress-dhcp-option-121-warnings</string>
+			<key>pfm_name</key>
+			<string>HideDHCP121Warnings</string>
+			<key>pfm_title</key>
+			<string>Suppress DHCP Option 121 warnings</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
 			<string>1.52</string>
 			<key>pfm_description</key>
 			<string>Specify a tailnet, and its identity provider will be used on the login page. If the policy value is prefixed with "required:"", Tailscale will force that identity provider to be used and won’t allow logging in with anything else.</string>
@@ -320,7 +320,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>required:example.com</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.38.1</string>
 			<key>pfm_description</key>
 			<string>The LoginURL policy can be used to specify a custom control server URL. This should not be changed unless you are not using the standard Tailscale server. Use this policy if you’re deploying your own server, such as Headscale.</string>
@@ -420,7 +420,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.80</string>
 			<key>pfm_description</key>
 			<string>The Hostname policy allows IT administrators to override the hostname configured in the operating system and reported to the coordination server. This can be particularly useful on mobile devices, where the hostname provided by the operating system usually only contains the device's manufacturer name and model.</string>
@@ -520,7 +520,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.50</string>
 			<key>pfm_default</key>
 			<string>show</string>
@@ -546,7 +546,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.50</string>
 			<key>pfm_default</key>
 			<string>show</string>
@@ -572,7 +572,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.50</string>
 			<key>pfm_default</key>
 			<string>show</string>
@@ -598,7 +598,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.50</string>
 			<key>pfm_default</key>
 			<string>show</string>
@@ -624,7 +624,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.50</string>
 			<key>pfm_default</key>
 			<string>show</string>
@@ -650,7 +650,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.50</string>
 			<key>pfm_default</key>
 			<string>show</string>
@@ -702,7 +702,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.52</string>
 			<key>pfm_description</key>
 			<string>Can be used to hide one or more categories of network devices normally displayed in the Tailscale client. Administrators can choose to hide: devices owned by the current user; devices owned by other users; tagged devices. If all three options are chosen, the "Network Devices" menu item disappears entirely and users aren’t able to see any device on the tailnet.</string>
@@ -735,7 +735,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>array</string>
 		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.50</string>
 			<key>pfm_description</key>
 			<string>When you use the Tailscale menu bar item to copy to the Clipboard the IP address of a device, a notification displaying the IP address is presented. Use this to suppress this Copied IP address to clipboard notification.</string>
@@ -748,20 +748,18 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
-        <dict>
+		<dict>
 			<key>pfm_app_min</key>
 			<string>1.68</string>
-            <key>pfm_default</key>
-            <string>hide</string>
+			<key>pfm_default</key>
+			<string>hide</string>
 			<key>pfm_description</key>
 			<string>When set to hide, the user will not be able to install the CLI helper, and will instead be told to contact their administrator.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://tailscale.com/kb/1315/mdm-keys#hide-the-cli-integration-installer</string>
 			<key>pfm_name</key>
 			<string>CLIIntegration</string>
-			<key>pfm_title</key>
-			<string>Hide the CLI integration installer</string>
-            <key>pfm_range_list</key>
+			<key>pfm_range_list</key>
 			<array>
 				<string>show</string>
 				<string>hide</string>
@@ -771,11 +769,13 @@ A profile can consist of payloads with different version numbers. For example, c
 				<string>Show</string>
 				<string>Hide</string>
 			</array>
+			<key>pfm_title</key>
+			<string>Hide the CLI integration installer</string>
 			<key>pfm_type</key>
 			<string>string</string>
-        </dict>
+		</dict>
 		<dict>
-            <key>pfm_app_min</key>
+			<key>pfm_app_min</key>
 			<string>1.46</string>
 			<key>pfm_description</key>
 			<string>When you start Tailscale on your Mac for the first time, an onboarding flow is presented. It explains the Tailscale privacy policy, and guides the user in setting up the VPN configuration on their Mac. You might want to disable this onboarding flow if you are going to automatically set up the VPN configuration on the system by using a configuration profile. In order to do so, this boolean suppresses the onboarding flow when Tailscale launches for the first time and the value is set to true.</string>

--- a/Manifests/ManagedPreferencesApplications/org.churchofjesuschrist.dorm.plist
+++ b/Manifests/ManagedPreferencesApplications/org.churchofjesuschrist.dorm.plist
@@ -203,14 +203,14 @@
 			<string>Controls restart workflow behavior after deadline. Valid values: Off | Prompt | Force.</string>
 			<key>pfm_name</key>
 			<string>PastDeadlineRestartBehavior</string>
-			<key>pfm_title</key>
-			<string>Past Deadline Restart Behavior</string>
 			<key>pfm_range_list</key>
 			<array>
 				<string>Off</string>
 				<string>Prompt</string>
 				<string>Force</string>
 			</array>
+			<key>pfm_title</key>
+			<string>Past Deadline Restart Behavior</string>
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>


### PR DESCRIPTION
Command: pre-commit run --all-files

- Auto-format XML property list (plist) files to use tabs instead of spaces.
- Alphabetically sort keys.