### PR TITLE
Update Claude Desktop Manifest: isDesktopExtensionSignatureRequired / disabledBuiltinTools / managedMcpServers

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
+++ b/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2026-02-24T10:11:42Z</date>
+	<date>2026-05-01T19:54:38Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -230,12 +230,156 @@
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>When true, Claude Desktop rejects extensions that aren't signed by a trusted publisher.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.claude.com/en/articles/14680753-extend-claude-cowork-with-third-party-platforms</string>
+			<key>pfm_name</key>
+			<string>isDesktopExtensionSignatureRequired</string>
+			<key>pfm_title</key>
+			<string>Require Signed Desktop Extensions</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Removes the listed built-in tools from the available set in Claude Desktop. Known tools: Task, Bash, Glob, Grep, Read, Edit, Write, NotebookEdit, WebFetch, TodoWrite, WebSearch, Skill, REPL, JavaScript, AskUserQuestion. ToolSearch and SendUserMessage are also available under specific conditions.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.claude.com/en/articles/14680753-extend-claude-cowork-with-third-party-platforms</string>
+			<key>pfm_name</key>
+			<string>disabledBuiltinTools</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_description</key>
+					<string>Name of a built-in tool to disable.</string>
+					<key>pfm_name</key>
+					<string>tool</string>
+					<key>pfm_title</key>
+					<string>Tool</string>
+					<key>pfm_type</key>
+					<string>string</string>
+					<key>pfm_value_placeholder</key>
+					<string>WebSearch</string>
+				</dict>
+			</array>
+			<key>pfm_title</key>
+			<string>Disabled Built-in Tools</string>
+			<key>pfm_type</key>
+			<string>array</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Distributes remote MCP (Model Context Protocol) servers to users. Each entry requires a unique name and an HTTPS URL. Optional fields include transport, headers, OAuth, and tool-level policies. Used in Claude Cowork deployments on third-party platforms (Bedrock, Vertex AI, Azure AI Foundry, LLM gateways).</string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.claude.com/en/articles/14680753-extend-claude-cowork-with-third-party-platforms</string>
+			<key>pfm_name</key>
+			<string>managedMcpServers</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_name</key>
+					<string>managedMcpServer</string>
+					<key>pfm_subkeys</key>
+					<array>
+						<dict>
+							<key>pfm_description</key>
+							<string>Unique name identifying this MCP server.</string>
+							<key>pfm_name</key>
+							<string>name</string>
+							<key>pfm_require</key>
+							<string>always</string>
+							<key>pfm_title</key>
+							<string>Name</string>
+							<key>pfm_type</key>
+							<string>string</string>
+							<key>pfm_value_placeholder</key>
+							<string>internal-tools</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>HTTPS URL of the remote MCP server.</string>
+							<key>pfm_name</key>
+							<string>url</string>
+							<key>pfm_require</key>
+							<string>always</string>
+							<key>pfm_title</key>
+							<string>URL</string>
+							<key>pfm_type</key>
+							<string>string</string>
+							<key>pfm_value_placeholder</key>
+							<string>https://mcp.example.corp/sse</string>
+						</dict>
+						<dict>
+							<key>pfm_default</key>
+							<string>http</string>
+							<key>pfm_description</key>
+							<string>Transport protocol used to reach the MCP server.</string>
+							<key>pfm_name</key>
+							<string>transport</string>
+							<key>pfm_range_list</key>
+							<array>
+								<string>http</string>
+								<string>sse</string>
+							</array>
+							<key>pfm_title</key>
+							<string>Transport</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>Static request headers used to authenticate to the MCP server (for example, Authorization). Mutually exclusive with the OAuth field.</string>
+							<key>pfm_name</key>
+							<string>headers</string>
+							<key>pfm_title</key>
+							<string>Headers</string>
+							<key>pfm_type</key>
+							<string>dictionary</string>
+						</dict>
+						<dict>
+							<key>pfm_default</key>
+							<false/>
+							<key>pfm_description</key>
+							<string>When true, Claude Desktop runs a PKCE OAuth flow at first use to acquire user credentials. Mutually exclusive with the Headers field.</string>
+							<key>pfm_name</key>
+							<string>oauth</string>
+							<key>pfm_title</key>
+							<string>OAuth</string>
+							<key>pfm_type</key>
+							<string>boolean</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>Maps tool names exposed by the MCP server to a policy. Allowed values per tool: allow, ask, blocked. The "ask" policy prompts the user to confirm before the tool runs.</string>
+							<key>pfm_name</key>
+							<string>toolPolicy</string>
+							<key>pfm_title</key>
+							<string>Tool Policy</string>
+							<key>pfm_type</key>
+							<string>dictionary</string>
+						</dict>
+					</array>
+					<key>pfm_title</key>
+					<string>Managed MCP Server</string>
+					<key>pfm_type</key>
+					<string>dictionary</string>
+				</dict>
+			</array>
+			<key>pfm_title</key>
+			<string>Managed MCP Servers</string>
+			<key>pfm_type</key>
+			<string>array</string>
+		</dict>
 	</array>
 	<key>pfm_title</key>
 	<string>Claude</string>
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
+++ b/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
@@ -257,7 +257,7 @@
 					<key>pfm_description</key>
 					<string>Name of a built-in tool to disable.</string>
 					<key>pfm_name</key>
-					<string>tool</string>
+					<string>disabledBuiltinToolsItem</string>
 					<key>pfm_title</key>
 					<string>Tool</string>
 					<key>pfm_type</key>
@@ -282,7 +282,7 @@
 			<array>
 				<dict>
 					<key>pfm_name</key>
-					<string>managedMcpServer</string>
+					<string>managedMcpServersItem</string>
 					<key>pfm_subkeys</key>
 					<array>
 						<dict>
@@ -325,6 +325,11 @@
 								<string>http</string>
 								<string>sse</string>
 							</array>
+							<key>pfm_range_list_titles</key>
+							<array>
+								<string>HTTP</string>
+								<string>SSE</string>
+							</array>
 							<key>pfm_title</key>
 							<string>Transport</string>
 							<key>pfm_type</key>
@@ -335,6 +340,25 @@
 							<string>Static request headers used to authenticate to the MCP server (for example, Authorization). Mutually exclusive with the OAuth field.</string>
 							<key>pfm_name</key>
 							<string>headers</string>
+							<key>pfm_subkeys</key>
+							<array>
+								<dict>
+									<key>pfm_name</key>
+									<string>{{key}}</string>
+									<key>pfm_title</key>
+									<string>Header Name</string>
+									<key>pfm_type</key>
+									<string>string</string>
+								</dict>
+								<dict>
+									<key>pfm_name</key>
+									<string>{{value}}</string>
+									<key>pfm_title</key>
+									<string>Header Value</string>
+									<key>pfm_type</key>
+									<string>string</string>
+								</dict>
+							</array>
 							<key>pfm_title</key>
 							<string>Headers</string>
 							<key>pfm_type</key>
@@ -357,6 +381,37 @@
 							<string>Maps tool names exposed by the MCP server to a policy. Allowed values per tool: allow, ask, blocked. The "ask" policy prompts the user to confirm before the tool runs.</string>
 							<key>pfm_name</key>
 							<string>toolPolicy</string>
+							<key>pfm_subkeys</key>
+							<array>
+								<dict>
+									<key>pfm_name</key>
+									<string>{{key}}</string>
+									<key>pfm_title</key>
+									<string>Tool Name</string>
+									<key>pfm_type</key>
+									<string>string</string>
+								</dict>
+								<dict>
+									<key>pfm_name</key>
+									<string>{{value}}</string>
+									<key>pfm_range_list</key>
+									<array>
+										<string>allow</string>
+										<string>ask</string>
+										<string>blocked</string>
+									</array>
+									<key>pfm_range_list_titles</key>
+									<array>
+										<string>Allow</string>
+										<string>Ask</string>
+										<string>Block</string>
+									</array>
+									<key>pfm_title</key>
+									<string>Policy</string>
+									<key>pfm_type</key>
+									<string>string</string>
+								</dict>
+							</array>
 							<key>pfm_title</key>
 							<string>Tool Policy</string>
 							<key>pfm_type</key>


### PR DESCRIPTION
Adds three MDM keys to the Claude Desktop manifest, documented by Anthropic at
https://support.claude.com/en/articles/14680753-extend-claude-cowork-with-third-party-platforms
but not yet present in this manifest.

### Notes

- `headers` and `toolPolicy` (inside `managedMcpServers`) are modeled as open `dictionary` types since both take arbitrary keys. Allowed `toolPolicy` values (`allow`, `ask`, `blocked`) are noted in the description.
- `disabledBuiltinTools` is left as a free-form string array (with known tool names listed in the description) rather than constrained to an enum, so it doesn't go stale when Anthropic adds new tools.
- No `pfm_app_min` set on the new keys — Anthropic's docs don't state when they shipped.
- `pfm_version` bumped 2 → 3, `pfm_last_modified` updated.