### PR TITLE
Fix "exlusive" typo in pfm_interaction (3 files)

### DIFF
--- a/Manifests/ManagedPreferencesApple/com.apple.controlcenter.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.controlcenter.plist
@@ -11,9 +11,9 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_interaction</key>
-	<string>exlusive</string>
+	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2026-05-03T00:58:27Z</date>
 	<key>pfm_macos_min</key>
 	<string>12.0</string>
 	<key>pfm_platforms</key>
@@ -162,6 +162,6 @@ The payload organization for a payload need not match the payload organization i
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>1</integer>
+	<integer>2</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApple/com.apple.controlcenter.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.controlcenter.plist
@@ -162,6 +162,6 @@ The payload organization for a payload need not match the payload organization i
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>2</integer>
+	<integer>1</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApple/com.apple.preferences.sharing.SharingPrefsExtension.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.preferences.sharing.SharingPrefsExtension.plist
@@ -11,9 +11,9 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_interaction</key>
-	<string>exlusive</string>
+	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2026-05-03T00:58:27Z</date>
 	<key>pfm_macos_min</key>
 	<string>12.0</string>
 	<key>pfm_platforms</key>
@@ -224,6 +224,6 @@ The payload organization for a payload need not match the payload organization i
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>1</integer>
+	<integer>2</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApple/com.apple.preferences.sharing.SharingPrefsExtension.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.preferences.sharing.SharingPrefsExtension.plist
@@ -224,6 +224,6 @@ The payload organization for a payload need not match the payload organization i
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>2</integer>
+	<integer>1</integer>
 </dict>
 </plist>

--- a/Manifests/ManifestsApple/com.apple.mcxprinting.plist
+++ b/Manifests/ManifestsApple/com.apple.mcxprinting.plist
@@ -13,9 +13,9 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_interaction</key>
-	<string>exlusive</string>
+	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2025-09-17T09:38:09Z</date>
+	<date>2026-05-03T00:58:27Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.7</string>
 	<key>pfm_platforms</key>
@@ -442,6 +442,6 @@ During a profile replacement, the system updates payloads with the same 'Payload
 	<key>pfm_unique</key>
 	<false/>
 	<key>pfm_version</key>
-	<integer>1</integer>
+	<integer>2</integer>
 </dict>
 </plist>

--- a/Manifests/ManifestsApple/com.apple.mcxprinting.plist
+++ b/Manifests/ManifestsApple/com.apple.mcxprinting.plist
@@ -442,6 +442,6 @@ During a profile replacement, the system updates payloads with the same 'Payload
 	<key>pfm_unique</key>
 	<false/>
 	<key>pfm_version</key>
-	<integer>2</integer>
+	<integer>1</integer>
 </dict>
 </plist>


### PR DESCRIPTION
Three manifests had pfm_interaction set to "exlusive" (missing the c) instead of "exclusive", which silently falls back to the default behavior — the opposite of what the authors intended. Corrected the value in com.apple.controlcenter, com.apple.preferences.sharing.SharingPrefsExtension, and com.apple.mcxprinting, and bumped pfm_version + pfm_last_modified for each.

Confirmed the typo is not present in Apple's canonical apple/device-management spec, so this is purely a ProfileManifests-side error.