### PR TITLE
Fix Baseline Retries integer defaults

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.secondsonconsulting.baseline.plist
+++ b/Manifests/ManagedPreferencesApplications/com.secondsonconsulting.baseline.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2026-04-07T00:00:00Z</date>
+	<date>2026-05-02T00:00:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -266,7 +266,7 @@ A profile can consist of payloads with different version numbers. For example, c
 						</dict>
 						<dict>
 							<key>pfm_default</key>
-							<false/>
+							<integer>0</integer>
 							<key>pfm_description</key>
 							<string>The number of times Baseline will retry this specific item if it fails. If omitted, will use the Global Retries Default.</string>
 							<key>pfm_name</key>
@@ -390,7 +390,7 @@ A profile can consist of payloads with different version numbers. For example, c
 						</dict>
 						<dict>
 							<key>pfm_default</key>
-							<false/>
+							<integer>0</integer>
 							<key>pfm_description</key>
 							<string>The number of times Baseline will retry this specific item if it fails. If omitted, will use the Global Retries Default.</string>
 							<key>pfm_name</key>
@@ -546,7 +546,7 @@ A profile can consist of payloads with different version numbers. For example, c
 						</dict>
 						<dict>
 							<key>pfm_default</key>
-							<false/>
+							<integer>0</integer>
 							<key>pfm_description</key>
 							<string>The number of times Baseline will retry this specific item if it fails. If omitted, will use the Global Retries Default.</string>
 							<key>pfm_name</key>
@@ -724,7 +724,7 @@ A profile can consist of payloads with different version numbers. For example, c
 						</dict>
 						<dict>
 							<key>pfm_default</key>
-							<false/>
+							<integer>0</integer>
 							<key>pfm_description</key>
 							<string>The number of times Baseline will retry this specific item if it fails. If omitted, will use the Global Retries Default.</string>
 							<key>pfm_name</key>
@@ -902,7 +902,7 @@ A profile can consist of payloads with different version numbers. For example, c
 						</dict>
 						<dict>
 							<key>pfm_default</key>
-							<false/>
+							<integer>0</integer>
 							<key>pfm_description</key>
 							<string>The number of times Baseline will retry this specific item if it fails. If omitted, will use the Global Retries Default.</string>
 							<key>pfm_name</key>
@@ -1300,6 +1300,6 @@ A profile can consist of payloads with different version numbers. For example, c
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>6</integer>
+	<integer>7</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/com.secondsonconsulting.baseline.plist
+++ b/Manifests/ManagedPreferencesApplications/com.secondsonconsulting.baseline.plist
@@ -1300,6 +1300,6 @@ A profile can consist of payloads with different version numbers. For example, c
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>7</integer>
+	<integer>6</integer>
 </dict>
 </plist>


### PR DESCRIPTION
The five nested `Retries` keys in com.secondsonconsulting.baseline are declared as `pfm_type` integer but had `<false/>` as their `pfm_default`, which is a type mismatch. Changed them to `<integer>0</integer>` to match the sibling top-level `DefaultInstallomatorRetries`/`DefaultScriptRetries`/`DefaultPackageRetries` already defined in the same manifest, and bumped pfm_version + pfm_last_modified.