### PR TITLE
Fix ProxyCaptiveLoginAllowed integer default

### DIFF
--- a/Manifests/ManifestsApple/com.apple.SystemConfiguration.plist
+++ b/Manifests/ManifestsApple/com.apple.SystemConfiguration.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2025-09-17T09:38:09Z</date>
+	<date>2026-05-02T00:00:00Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.7</string>
 	<key>pfm_platforms</key>
@@ -478,7 +478,7 @@ For managed devices, if not supplied, the default is '0'.</string>
 				</dict>
 				<dict>
 					<key>pfm_default</key>
-					<false/>
+					<integer>0</integer>
 					<key>pfm_description</key>
 					<string>If 1, allows client to log into captive portal network.</string>
 					<key>pfm_macos_min</key>
@@ -516,6 +516,6 @@ For managed devices, if not supplied, the default is '0'.</string>
 	<key>pfm_unique</key>
 	<false/>
 	<key>pfm_version</key>
-	<integer>4</integer>
+	<integer>5</integer>
 </dict>
 </plist>

--- a/Manifests/ManifestsApple/com.apple.SystemConfiguration.plist
+++ b/Manifests/ManifestsApple/com.apple.SystemConfiguration.plist
@@ -516,6 +516,6 @@ For managed devices, if not supplied, the default is '0'.</string>
 	<key>pfm_unique</key>
 	<false/>
 	<key>pfm_version</key>
-	<integer>5</integer>
+	<integer>4</integer>
 </dict>
 </plist>


### PR DESCRIPTION
The `ProxyCaptiveLoginAllowed` subkey under `com.apple.SystemConfiguration` Proxies is declared as `pfm_type` integer (matching Apple's canonical device-management spec, which lists `type: <integer>` and the description "If 1, allows client to log into captive portal network"), but its `pfm_default` was `<false/>` — a type mismatch. Changed to `<integer>0</integer>`, which matches the 15 sibling integer-typed keys in the same manifest, and bumped pfm_version + pfm_last_modified.