### PR TITLE
Zappl | Adding conditional pfm keys

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.dare.zappl.preferences.plist
+++ b/Manifests/ManagedPreferencesApplications/com.dare.zappl.preferences.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2026-04-22T00:00:00Z</date>
+	<date>2026-04-30T00:00:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -221,6 +221,8 @@ A profile can consist of payloads with different version numbers. For example, c
 					<string>https://docs.zappl.co/customise/preferences#allow-background-updates</string>
 					<key>pfm_name</key>
 					<string>hourlyCheck</string>
+					<key>pfm_note</key>
+					<string>Enable this setting to configure the 'Background Update Stagger Window' (backgroundUpdateWindow) preference.</string>
 					<key>pfm_title</key>
 					<string>Allow Background Updates</string>
 					<key>pfm_type</key>
@@ -235,6 +237,22 @@ A profile can consist of payloads with different version numbers. For example, c
 					<string>Sets a stagger window in minutes that spreads background update checks across your devices. Each device will randomly pick a time within this window to check for and download new updates after they are released. Increasing this value is recommended for large sites to reduce network load. The default and minimum value is 60 minutes and the maximum is 360 minutes (6 hours).</string>
 					<key>pfm_documentation_url</key>
 					<string>https://docs.zappl.co/customise/preferences#background-update-stagger-window</string>
+					<key>pfm_exclude</key>
+					<array>
+						<dict>
+							<key>pfm_target_conditions</key>
+							<array>
+								<dict>
+									<key>pfm_range_list</key>
+									<array>
+										<false/>
+									</array>
+									<key>pfm_target</key>
+									<string>GeneralOptions.hourlyCheck</string>
+								</dict>
+							</array>
+						</dict>
+					</array>
 					<key>pfm_name</key>
 					<string>backgroundUpdateWindow</string>
 					<key>pfm_range_max</key>
@@ -421,6 +439,8 @@ A profile can consist of payloads with different version numbers. For example, c
 							<true/>
 							<key>pfm_name</key>
 							<string>runType</string>
+							<key>pfm_note</key>
+							<string>When set to 'Specify Patch Frequency', the following preferences are available: 'Frequency to prompt users' (frequencyOption), 'Frequency Elapsed Behaviour' (frequencyElapsedMode), and 'Recurring Prompt Mode Deferral Window (Patch Frequency)' (deferralWindow). When set to 'Specify Recurring Patch Day', the following preferences are available: 'Patch Day' (patchDay), 'Week(s) of Month' (patchDayWeeks), 'Patch Day Prompt Frequency' (patchDayFrequency), 'Recurring Prompt Mode Deferral Window (Patch Day)' (patchDayDeferralWindow), and 'Missed Update Prompts' (missedUpdatePrompt).</string>
 							<key>pfm_range_list</key>
 							<array>
 								<string>specifyFrequency</string>
@@ -443,6 +463,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>A recurring update frequency time window which determines how often users are prompted to install pending updates, e.g. Once every week.</string>
 							<key>pfm_documentation_url</key>
 							<string>https://docs.zappl.co/customise/preferences#specific-patch-frequency-preferences</string>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<string>specifyPatchDay</string>
+											</array>
+											<key>pfm_target</key>
+											<string>ScheduledUpdates.runFrequency.runType</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_name</key>
 							<string>frequencyOption</string>
 							<key>pfm_range_list</key>
@@ -475,8 +511,26 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#specific-patch-frequency-preferences</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<string>specifyPatchDay</string>
+											</array>
+											<key>pfm_target</key>
+											<string>ScheduledUpdates.runFrequency.runType</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_name</key>
 							<string>frequencyElapsedMode</string>
+							<key>pfm_note</key>
+							<string>Set to 'Recurring Prompt Mode' to configure the 'Recurring Prompt Mode Deferral Window (Patch Frequency)' (deferralWindow) preference.</string>
 							<key>pfm_range_list</key>
 							<array>
 								<string>singlePromptMode</string>
@@ -501,6 +555,35 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#specific-patch-day-preferences</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<string>specifyPatchDay</string>
+											</array>
+											<key>pfm_target</key>
+											<string>ScheduledUpdates.runFrequency.runType</string>
+										</dict>
+									</array>
+								</dict>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_n_contains_any</key>
+											<array>
+												<string>recurringPromptMode</string>
+											</array>
+											<key>pfm_target</key>
+											<string>ScheduledUpdates.runFrequency.frequencyElapsedMode</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_name</key>
 							<string>deferralWindow</string>
 							<key>pfm_title</key>
@@ -519,6 +602,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#specific-patch-day-preferences</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<string>specifyFrequency</string>
+											</array>
+											<key>pfm_target</key>
+											<string>ScheduledUpdates.runFrequency.runType</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_name</key>
 							<string>patchDay</string>
 							<key>pfm_range_list</key>
@@ -557,6 +656,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#specific-patch-day-preferences</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<string>specifyFrequency</string>
+											</array>
+											<key>pfm_target</key>
+											<string>ScheduledUpdates.runFrequency.runType</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_name</key>
 							<string>patchDayWeeks</string>
 							<key>pfm_subkeys</key>
@@ -636,8 +751,26 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#specific-patch-day-preferences</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<string>specifyFrequency</string>
+											</array>
+											<key>pfm_target</key>
+											<string>ScheduledUpdates.runFrequency.runType</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_name</key>
 							<string>patchDayFrequency</string>
+							<key>pfm_note</key>
+							<string>Set to 'Recurring Prompt Mode' to configure the 'Recurring Prompt Mode Deferral Window (Patch Day)' (patchDayDeferralWindow) preference.</string>
 							<key>pfm_range_list</key>
 							<array>
 								<string>singlePromptMode</string>
@@ -662,6 +795,35 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#specific-patch-frequency-preferences</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<string>specifyFrequency</string>
+											</array>
+											<key>pfm_target</key>
+											<string>ScheduledUpdates.runFrequency.runType</string>
+										</dict>
+									</array>
+								</dict>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<string>singlePromptMode</string>
+											</array>
+											<key>pfm_target</key>
+											<string>ScheduledUpdates.runFrequency.patchDayFrequency</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_name</key>
 							<string>patchDayDeferralWindow</string>
 							<key>pfm_title</key>
@@ -680,6 +842,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#specific-patch-day-preferences</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<string>specifyFrequency</string>
+											</array>
+											<key>pfm_target</key>
+											<string>ScheduledUpdates.runFrequency.runType</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_name</key>
 							<string>missedUpdatePrompt</string>
 							<key>pfm_title</key>
@@ -711,6 +889,8 @@ A profile can consist of payloads with different version numbers. For example, c
 							<true/>
 							<key>pfm_name</key>
 							<string>monday</string>
+							<key>pfm_note</key>
+							<string>Enable this setting to configure the 'Monday Start Time' (mondayStartTime) and 'Monday End Time' (mondayEndTime) preferences.</string>
 							<key>pfm_title</key>
 							<string>Monday</string>
 							<key>pfm_type</key>
@@ -723,6 +903,38 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>If you allowed updates on Mondays, use to define the time on a Monday Zappl is permitted to start prompting users to install pending updates. This should be in 24 hour format, e.g., 09:00 for 9am, or 21:00 for 9pm.</string>
 							<key>pfm_documentation_url</key>
 							<string>https://docs.zappl.co/customise/preferences#run-limitation-options</string>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<false/>
+											</array>
+											<key>pfm_target</key>
+											<string>ScheduledUpdates.runLimitations.monday</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<false/>
+											</array>
+											<key>pfm_target</key>
+											<string>ScheduledUpdates.runLimitations.monday</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_format</key>
 							<string>^$|^(?:[01]\d|2[0-3]):[0-5]\d$</string>
 							<key>pfm_name</key>
@@ -743,6 +955,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#run-limitation-options</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<false/>
+											</array>
+											<key>pfm_target</key>
+											<string>ScheduledUpdates.runLimitations.monday</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_format</key>
 							<string>^$|^(?:[01]\d|2[0-3]):[0-5]\d$</string>
 							<key>pfm_name</key>
@@ -765,6 +993,8 @@ A profile can consist of payloads with different version numbers. For example, c
 							<true/>
 							<key>pfm_name</key>
 							<string>tuesday</string>
+							<key>pfm_note</key>
+							<string>Enable this setting to configure the 'Tuesday Start Time' (tuesdayStartTime) and 'Tuesday End Time' (tuesdayEndTime) preferences.</string>
 							<key>pfm_title</key>
 							<string>Tuesday</string>
 							<key>pfm_type</key>
@@ -779,6 +1009,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#run-limitation-options</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<false/>
+											</array>
+											<key>pfm_target</key>
+											<string>ScheduledUpdates.runLimitations.tuesday</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_format</key>
 							<string>^$|^(?:[01]\d|2[0-3]):[0-5]\d$</string>
 							<key>pfm_name</key>
@@ -799,6 +1045,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#run-limitation-options</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<false/>
+											</array>
+											<key>pfm_target</key>
+											<string>ScheduledUpdates.runLimitations.tuesday</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_format</key>
 							<string>^$|^(?:[01]\d|2[0-3]):[0-5]\d$</string>
 							<key>pfm_name</key>
@@ -821,6 +1083,8 @@ A profile can consist of payloads with different version numbers. For example, c
 							<true/>
 							<key>pfm_name</key>
 							<string>wednesday</string>
+							<key>pfm_note</key>
+							<string>Enable this setting to configure the 'Wednesday Start Time' (wednesdayStartTime) and 'Wednesday End Time' (wednesdayEndTime) preferences.</string>
 							<key>pfm_title</key>
 							<string>Wednesday</string>
 							<key>pfm_type</key>
@@ -835,6 +1099,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#run-limitation-options</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<false/>
+											</array>
+											<key>pfm_target</key>
+											<string>ScheduledUpdates.runLimitations.wednesday</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_format</key>
 							<string>^$|^(?:[01]\d|2[0-3]):[0-5]\d$</string>
 							<key>pfm_name</key>
@@ -855,6 +1135,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#run-limitation-options</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<false/>
+											</array>
+											<key>pfm_target</key>
+											<string>ScheduledUpdates.runLimitations.wednesday</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_format</key>
 							<string>^$|^(?:[01]\d|2[0-3]):[0-5]\d$</string>
 							<key>pfm_name</key>
@@ -877,6 +1173,8 @@ A profile can consist of payloads with different version numbers. For example, c
 							<true/>
 							<key>pfm_name</key>
 							<string>thursday</string>
+							<key>pfm_note</key>
+							<string>Enable this setting to configure the 'Thursday Start Time' (thursdayStartTime) and 'Thursday End Time' (thursdayEndTime) preferences.</string>
 							<key>pfm_title</key>
 							<string>Thursday</string>
 							<key>pfm_type</key>
@@ -891,6 +1189,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#run-limitation-options</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<false/>
+											</array>
+											<key>pfm_target</key>
+											<string>ScheduledUpdates.runLimitations.thursday</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_format</key>
 							<string>^$|^(?:[01]\d|2[0-3]):[0-5]\d$</string>
 							<key>pfm_name</key>
@@ -911,6 +1225,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#run-limitation-options</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<false/>
+											</array>
+											<key>pfm_target</key>
+											<string>ScheduledUpdates.runLimitations.thursday</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_format</key>
 							<string>^$|^(?:[01]\d|2[0-3]):[0-5]\d$</string>
 							<key>pfm_name</key>
@@ -933,6 +1263,8 @@ A profile can consist of payloads with different version numbers. For example, c
 							<true/>
 							<key>pfm_name</key>
 							<string>friday</string>
+							<key>pfm_note</key>
+							<string>Enable this setting to configure the 'Friday Start Time' (fridayStartTime) and 'Friday End Time' (fridayEndTime) preferences.</string>
 							<key>pfm_title</key>
 							<string>Friday</string>
 							<key>pfm_type</key>
@@ -947,6 +1279,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#run-limitation-options</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<false/>
+											</array>
+											<key>pfm_target</key>
+											<string>ScheduledUpdates.runLimitations.friday</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_format</key>
 							<string>^$|^(?:[01]\d|2[0-3]):[0-5]\d$</string>
 							<key>pfm_name</key>
@@ -967,6 +1315,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#run-limitation-options</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<false/>
+											</array>
+											<key>pfm_target</key>
+											<string>ScheduledUpdates.runLimitations.friday</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_format</key>
 							<string>^$|^(?:[01]\d|2[0-3]):[0-5]\d$</string>
 							<key>pfm_name</key>
@@ -989,6 +1353,8 @@ A profile can consist of payloads with different version numbers. For example, c
 							<true/>
 							<key>pfm_name</key>
 							<string>saturday</string>
+							<key>pfm_note</key>
+							<string>Enable this setting to configure the 'Saturday Start Time' (saturdayStartTime) and 'Saturday End Time' (saturdayEndTime) preferences.</string>
 							<key>pfm_title</key>
 							<string>Saturday</string>
 							<key>pfm_type</key>
@@ -1003,6 +1369,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#run-limitation-options</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<false/>
+											</array>
+											<key>pfm_target</key>
+											<string>ScheduledUpdates.runLimitations.saturday</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_format</key>
 							<string>^$|^(?:[01]\d|2[0-3]):[0-5]\d$</string>
 							<key>pfm_name</key>
@@ -1023,6 +1405,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#run-limitation-options</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<false/>
+											</array>
+											<key>pfm_target</key>
+											<string>ScheduledUpdates.runLimitations.saturday</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_format</key>
 							<string>^$|^(?:[01]\d|2[0-3]):[0-5]\d$</string>
 							<key>pfm_name</key>
@@ -1045,6 +1443,8 @@ A profile can consist of payloads with different version numbers. For example, c
 							<true/>
 							<key>pfm_name</key>
 							<string>sunday</string>
+							<key>pfm_note</key>
+							<string>Enable this setting to configure the 'Sunday Start Time' (sundayStartTime) and 'Sunday End Time' (sundayEndTime) preferences.</string>
 							<key>pfm_title</key>
 							<string>Sunday</string>
 							<key>pfm_type</key>
@@ -1059,6 +1459,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#run-limitation-options</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<false/>
+											</array>
+											<key>pfm_target</key>
+											<string>ScheduledUpdates.runLimitations.sunday</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_format</key>
 							<string>^$|^(?:[01]\d|2[0-3]):[0-5]\d$</string>
 							<key>pfm_name</key>
@@ -1079,6 +1495,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#run-limitation-options</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<false/>
+											</array>
+											<key>pfm_target</key>
+											<string>ScheduledUpdates.runLimitations.sunday</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_format</key>
 							<string>^$|^(?:[01]\d|2[0-3]):[0-5]\d$</string>
 							<key>pfm_name</key>
@@ -1114,6 +1546,8 @@ A profile can consist of payloads with different version numbers. For example, c
 							<true/>
 							<key>pfm_name</key>
 							<string>deferralOption</string>
+							<key>pfm_note</key>
+							<string>Set to 'Specify Deferral Limit' to configure the 'Deferral Limit' (specifyLimit) preference. Setting to 'Disable Deferral Limit' or 'Disable Deferrals' will hide the 'Deferral Limit' preference.</string>
 							<key>pfm_range_list</key>
 							<array>
 								<string>disableDeferralLimit</string>
@@ -1140,6 +1574,35 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#deferral-options</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<string>disableDeferralLimit</string>
+											</array>
+											<key>pfm_target</key>
+											<string>ScheduledUpdates.deferralConfiguration.deferralOption</string>
+										</dict>
+									</array>
+								</dict>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<string>disableDeferrals</string>
+											</array>
+											<key>pfm_target</key>
+											<string>ScheduledUpdates.deferralConfiguration.deferralOption</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_name</key>
 							<string>specifyLimit</string>
 							<key>pfm_title</key>
@@ -1825,6 +2288,8 @@ A profile can consist of payloads with different version numbers. For example, c
 							<true/>
 							<key>pfm_name</key>
 							<string>monday</string>
+							<key>pfm_note</key>
+							<string>Enable this setting to configure the 'Monday Start Time' (mondayStartTime) and 'Monday End Time' (mondayEndTime) preferences.</string>
 							<key>pfm_title</key>
 							<string>Monday</string>
 							<key>pfm_type</key>
@@ -1839,6 +2304,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#run-limitation-options</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<false/>
+											</array>
+											<key>pfm_target</key>
+											<string>ForcedUpdates.runLimitations.monday</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_format</key>
 							<string>^$|^(?:[01]\d|2[0-3]):[0-5]\d$</string>
 							<key>pfm_name</key>
@@ -1859,6 +2340,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#run-limitation-options</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<false/>
+											</array>
+											<key>pfm_target</key>
+											<string>ForcedUpdates.runLimitations.monday</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_format</key>
 							<string>^$|^(?:[01]\d|2[0-3]):[0-5]\d$</string>
 							<key>pfm_name</key>
@@ -1881,6 +2378,8 @@ A profile can consist of payloads with different version numbers. For example, c
 							<true/>
 							<key>pfm_name</key>
 							<string>tuesday</string>
+							<key>pfm_note</key>
+							<string>Enable this setting to configure the 'Tuesday Start Time' (tuesdayStartTime) and 'Tuesday End Time' (tuesdayEndTime) preferences.</string>
 							<key>pfm_title</key>
 							<string>Tuesday</string>
 							<key>pfm_type</key>
@@ -1895,6 +2394,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#run-limitation-options</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<false/>
+											</array>
+											<key>pfm_target</key>
+											<string>ForcedUpdates.runLimitations.tuesday</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_format</key>
 							<string>^$|^(?:[01]\d|2[0-3]):[0-5]\d$</string>
 							<key>pfm_name</key>
@@ -1915,6 +2430,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#run-limitation-options</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<false/>
+											</array>
+											<key>pfm_target</key>
+											<string>ForcedUpdates.runLimitations.tuesday</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_format</key>
 							<string>^$|^(?:[01]\d|2[0-3]):[0-5]\d$</string>
 							<key>pfm_name</key>
@@ -1937,6 +2468,8 @@ A profile can consist of payloads with different version numbers. For example, c
 							<true/>
 							<key>pfm_name</key>
 							<string>wednesday</string>
+							<key>pfm_note</key>
+							<string>Enable this setting to configure the 'Wednesday Start Time' (wednesdayStartTime) and 'Wednesday End Time' (wednesdayEndTime) preferences.</string>
 							<key>pfm_title</key>
 							<string>Wednesday</string>
 							<key>pfm_type</key>
@@ -1951,6 +2484,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#run-limitation-options</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<false/>
+											</array>
+											<key>pfm_target</key>
+											<string>ForcedUpdates.runLimitations.wednesday</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_format</key>
 							<string>^$|^(?:[01]\d|2[0-3]):[0-5]\d$</string>
 							<key>pfm_name</key>
@@ -1971,6 +2520,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#run-limitation-options</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<false/>
+											</array>
+											<key>pfm_target</key>
+											<string>ForcedUpdates.runLimitations.wednesday</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_format</key>
 							<string>^$|^(?:[01]\d|2[0-3]):[0-5]\d$</string>
 							<key>pfm_name</key>
@@ -1993,6 +2558,8 @@ A profile can consist of payloads with different version numbers. For example, c
 							<true/>
 							<key>pfm_name</key>
 							<string>thursday</string>
+							<key>pfm_note</key>
+							<string>Enable this setting to configure the 'Thursday Start Time' (thursdayStartTime) and 'Thursday End Time' (thursdayEndTime) preferences.</string>
 							<key>pfm_title</key>
 							<string>Thursday</string>
 							<key>pfm_type</key>
@@ -2007,6 +2574,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#run-limitation-options</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<false/>
+											</array>
+											<key>pfm_target</key>
+											<string>ForcedUpdates.runLimitations.thursday</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_format</key>
 							<string>^$|^(?:[01]\d|2[0-3]):[0-5]\d$</string>
 							<key>pfm_name</key>
@@ -2027,6 +2610,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#run-limitation-options</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<false/>
+											</array>
+											<key>pfm_target</key>
+											<string>ForcedUpdates.runLimitations.thursday</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_format</key>
 							<string>^$|^(?:[01]\d|2[0-3]):[0-5]\d$</string>
 							<key>pfm_name</key>
@@ -2049,6 +2648,8 @@ A profile can consist of payloads with different version numbers. For example, c
 							<true/>
 							<key>pfm_name</key>
 							<string>friday</string>
+							<key>pfm_note</key>
+							<string>Enable this setting to configure the 'Friday Start Time' (fridayStartTime) and 'Friday End Time' (fridayEndTime) preferences.</string>
 							<key>pfm_title</key>
 							<string>Friday</string>
 							<key>pfm_type</key>
@@ -2063,6 +2664,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#run-limitation-options</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<false/>
+											</array>
+											<key>pfm_target</key>
+											<string>ForcedUpdates.runLimitations.friday</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_format</key>
 							<string>^$|^(?:[01]\d|2[0-3]):[0-5]\d$</string>
 							<key>pfm_name</key>
@@ -2083,6 +2700,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#run-limitation-options</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<false/>
+											</array>
+											<key>pfm_target</key>
+											<string>ForcedUpdates.runLimitations.friday</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_format</key>
 							<string>^$|^(?:[01]\d|2[0-3]):[0-5]\d$</string>
 							<key>pfm_name</key>
@@ -2105,6 +2738,8 @@ A profile can consist of payloads with different version numbers. For example, c
 							<true/>
 							<key>pfm_name</key>
 							<string>saturday</string>
+							<key>pfm_note</key>
+							<string>Enable this setting to configure the 'Saturday Start Time' (saturdayStartTime) and 'Saturday End Time' (saturdayEndTime) preferences.</string>
 							<key>pfm_title</key>
 							<string>Saturday</string>
 							<key>pfm_type</key>
@@ -2119,6 +2754,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#run-limitation-options</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<false/>
+											</array>
+											<key>pfm_target</key>
+											<string>ForcedUpdates.runLimitations.saturday</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_format</key>
 							<string>^$|^(?:[01]\d|2[0-3]):[0-5]\d$</string>
 							<key>pfm_name</key>
@@ -2139,6 +2790,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#run-limitation-options</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<false/>
+											</array>
+											<key>pfm_target</key>
+											<string>ForcedUpdates.runLimitations.saturday</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_format</key>
 							<string>^$|^(?:[01]\d|2[0-3]):[0-5]\d$</string>
 							<key>pfm_name</key>
@@ -2161,6 +2828,8 @@ A profile can consist of payloads with different version numbers. For example, c
 							<true/>
 							<key>pfm_name</key>
 							<string>sunday</string>
+							<key>pfm_note</key>
+							<string>Enable this setting to configure the 'Sunday Start Time' (sundayStartTime) and 'Sunday End Time' (sundayEndTime) preferences.</string>
 							<key>pfm_title</key>
 							<string>Sunday</string>
 							<key>pfm_type</key>
@@ -2175,6 +2844,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#run-limitation-options</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<false/>
+											</array>
+											<key>pfm_target</key>
+											<string>ForcedUpdates.runLimitations.sunday</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_format</key>
 							<string>^$|^(?:[01]\d|2[0-3]):[0-5]\d$</string>
 							<key>pfm_name</key>
@@ -2195,6 +2880,22 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>https://docs.zappl.co/customise/preferences#run-limitation-options</string>
 							<key>pfm_enabled</key>
 							<true/>
+							<key>pfm_exclude</key>
+							<array>
+								<dict>
+									<key>pfm_target_conditions</key>
+									<array>
+										<dict>
+											<key>pfm_range_list</key>
+											<array>
+												<false/>
+											</array>
+											<key>pfm_target</key>
+											<string>ForcedUpdates.runLimitations.sunday</string>
+										</dict>
+									</array>
+								</dict>
+							</array>
 							<key>pfm_format</key>
 							<string>^$|^(?:[01]\d|2[0-3]):[0-5]\d$</string>
 							<key>pfm_name</key>
@@ -2674,6 +3375,6 @@ A profile can consist of payloads with different version numbers. For example, c
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/com.dare.zappl.preferences.plist
+++ b/Manifests/ManagedPreferencesApplications/com.dare.zappl.preferences.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2026-04-30T00:00:00Z</date>
+	<date>2026-05-21T00:00:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -608,9 +608,9 @@ A profile can consist of payloads with different version numbers. For example, c
 									<key>pfm_target_conditions</key>
 									<array>
 										<dict>
-											<key>pfm_range_list</key>
+											<key>pfm_n_range_list</key>
 											<array>
-												<string>specifyFrequency</string>
+												<string>specifyPatchDay</string>
 											</array>
 											<key>pfm_target</key>
 											<string>ScheduledUpdates.runFrequency.runType</string>
@@ -662,9 +662,9 @@ A profile can consist of payloads with different version numbers. For example, c
 									<key>pfm_target_conditions</key>
 									<array>
 										<dict>
-											<key>pfm_range_list</key>
+											<key>pfm_n_range_list</key>
 											<array>
-												<string>specifyFrequency</string>
+												<string>specifyPatchDay</string>
 											</array>
 											<key>pfm_target</key>
 											<string>ScheduledUpdates.runFrequency.runType</string>
@@ -757,9 +757,9 @@ A profile can consist of payloads with different version numbers. For example, c
 									<key>pfm_target_conditions</key>
 									<array>
 										<dict>
-											<key>pfm_range_list</key>
+											<key>pfm_n_range_list</key>
 											<array>
-												<string>specifyFrequency</string>
+												<string>specifyPatchDay</string>
 											</array>
 											<key>pfm_target</key>
 											<string>ScheduledUpdates.runFrequency.runType</string>
@@ -801,9 +801,9 @@ A profile can consist of payloads with different version numbers. For example, c
 									<key>pfm_target_conditions</key>
 									<array>
 										<dict>
-											<key>pfm_range_list</key>
+											<key>pfm_n_range_list</key>
 											<array>
-												<string>specifyFrequency</string>
+												<string>specifyPatchDay</string>
 											</array>
 											<key>pfm_target</key>
 											<string>ScheduledUpdates.runFrequency.runType</string>
@@ -814,9 +814,9 @@ A profile can consist of payloads with different version numbers. For example, c
 									<key>pfm_target_conditions</key>
 									<array>
 										<dict>
-											<key>pfm_range_list</key>
+											<key>pfm_n_range_list</key>
 											<array>
-												<string>singlePromptMode</string>
+												<string>recurringPromptMode</string>
 											</array>
 											<key>pfm_target</key>
 											<string>ScheduledUpdates.runFrequency.patchDayFrequency</string>
@@ -848,9 +848,9 @@ A profile can consist of payloads with different version numbers. For example, c
 									<key>pfm_target_conditions</key>
 									<array>
 										<dict>
-											<key>pfm_range_list</key>
+											<key>pfm_n_range_list</key>
 											<array>
-												<string>specifyFrequency</string>
+												<string>specifyPatchDay</string>
 											</array>
 											<key>pfm_target</key>
 											<string>ScheduledUpdates.runFrequency.runType</string>
@@ -903,22 +903,8 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>If you allowed updates on Mondays, use to define the time on a Monday Zappl is permitted to start prompting users to install pending updates. This should be in 24 hour format, e.g., 09:00 for 9am, or 21:00 for 9pm.</string>
 							<key>pfm_documentation_url</key>
 							<string>https://docs.zappl.co/customise/preferences#run-limitation-options</string>
-							<key>pfm_exclude</key>
-							<array>
-								<dict>
-									<key>pfm_target_conditions</key>
-									<array>
-										<dict>
-											<key>pfm_range_list</key>
-											<array>
-												<false/>
-											</array>
-											<key>pfm_target</key>
-											<string>ScheduledUpdates.runLimitations.monday</string>
-										</dict>
-									</array>
-								</dict>
-							</array>
+							<key>pfm_enabled</key>
+							<true/>
 							<key>pfm_exclude</key>
 							<array>
 								<dict>

--- a/Manifests/ManagedPreferencesApplications/com.dare.zappl.preferences.plist
+++ b/Manifests/ManagedPreferencesApplications/com.dare.zappl.preferences.plist
@@ -3375,6 +3375,6 @@ A profile can consist of payloads with different version numbers. For example, c
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>3</integer>
+	<integer>2</integer>
 </dict>
 </plist>


### PR DESCRIPTION
Hello, me again ☺️

We've received some community feedback that highlighted a need for us to show/hide certain preferences that are reliant on the values of other keys.
This PR includes the addition of `pfm_exclude` and `pfm_target_conditions` keys where relevant, as well as `pfm_note` keys to help describe the conditions that need to be met.

As always, I appreciate the time and support provided!