### PR TITLE
Add forceLoginOrgUUID key to com.anthropic.claudefordesktop

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
+++ b/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
@@ -133,8 +133,6 @@
 		<dict>
 			<key>pfm_description</key>
 			<string>Forces users to sign in with the specified Anthropic organization. When set, Claude Desktop requires the user to authenticate with the matching organization UUID.</string>
-			<key>pfm_documentation_url</key>
-			<string>https://code.claude.com/docs/en/settings</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>

--- a/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
+++ b/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
@@ -134,7 +134,7 @@
 			<key>pfm_description</key>
 			<string>Forces users to sign in with the specified Anthropic organization. When set, Claude Desktop requires the user to authenticate with the matching organization UUID.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://support.claude.com/en/articles/12622667-enterprise-configuration</string>
+			<string>https://code.claude.com/docs/en/settings</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>

--- a/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
+++ b/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
@@ -445,7 +445,7 @@
 		</dict>
 	</array>
 	<key>pfm_title</key>
-	<string>Claude</string>
+	<string>Claude Desktop</string>
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>

--- a/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
+++ b/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2026-05-02T00:00:00Z</date>
+	<date>2026-05-18T00:00:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -129,6 +129,22 @@
 			<string>Payload Organization</string>
 			<key>pfm_type</key>
 			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Forces users to sign in with the specified Anthropic organization. When set, Claude Desktop requires the user to authenticate with the matching organization UUID.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.claude.com/en/articles/12622667-enterprise-configuration</string>
+			<key>pfm_format</key>
+			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
+			<key>pfm_name</key>
+			<string>forceLoginOrgUUID</string>
+			<key>pfm_title</key>
+			<string>Force Login Organization UUID</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_value_placeholder</key>
+			<string>ef923b16-deb9-4c5c-a35c-3dfb21ab857b</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
@@ -433,6 +449,6 @@
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>3</integer>
+	<integer>4</integer>
 </dict>
 </plist>


### PR DESCRIPTION
Adds the `forceLoginOrgUUID` preference key to the Claude Desktop manifest. When set via MDM, this forces users to sign in with a specific Anthropic organization, enforcing enterprise authentication.

Validated on macOS with Jamf Pro using the Application & Custom Settings > Upload method. The preference lands correctly in `/Library/Managed Preferences/com.anthropic.claudefordesktop` and is read by Claude Desktop on next launch.