### PR TITLE
Microsoft Office broken documentation URL replacement

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.microsoft.Excel.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.Excel.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2026-05-20T09:05:42Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -274,7 +274,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<key>pfm_description</key>
 			<string>Suppresses a temporary Privacy and Services Update dialog in 16.27 ONLY. (Was previously used for a similar purpose in 16.13.1 but the key was recycled.)</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/16.28-Privacy-Consent.key</string>
+			<string>https://www.kevinmcox.com/2019/08/privacy-and-consent-changes-in-microsoft-office-16-28/</string>
 			<key>pfm_name</key>
 			<string>kFREEnterpriseTelemetryInfoKey</string>
 			<key>pfm_title</key>
@@ -294,7 +294,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<key>pfm_description_reference</key>
 			<string>Users who are activated with O365 will see a new "Use Intelligent Services?" pop-up dialog in Word, Excel &amp; PowerPoint after updating to 16.17. The net effect of doing this will enable Researcher (Word), Translate (Word, Excel, PowerPoint), Smart Lookup (Word, PowerPoint), and QuickStarter (PowerPoint). Set to TRUE to auto-accept. Requires "PII_And_Intelligent_Services_Preference" as well.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/16.28-Privacy-Consent.key</string>
+			<string>https://www.kevinmcox.com/2019/08/privacy-and-consent-changes-in-microsoft-office-16-28/</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -336,7 +336,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<key>pfm_description_reference</key>
 			<string>Users who are activated with O365 will see a new "Use Intelligent Services?" pop-up dialog in Word, Excel &amp; PowerPoint after updating to 16.17. The net effect of doing this will enable Researcher (Word), Translate (Word, Excel, PowerPoint), Smart Lookup (Word, PowerPoint), and QuickStarter (PowerPoint). Set to TRUE to auto-accept. Requires "kFREIntelligenceServicesConsentV2Key" as well.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/16.28-Privacy-Consent.key</string>
+			<string>https://www.kevinmcox.com/2019/08/privacy-and-consent-changes-in-microsoft-office-16-28/</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.Outlook.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.Outlook.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2025-10-13T09:08:01Z</date>
+	<date>2026-05-20T09:05:42Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -677,7 +677,7 @@ You or administrators may want to suppress the initial warning message.</string>
 			<key>pfm_description</key>
 			<string>Suppresses a temporary Privacy and Services Update dialog in 16.27 ONLY. (Was previously used for a similar purpose in 16.13.1 but the key was recycled.)</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/16.28-Privacy-Consent.key</string>
+			<string>https://www.kevinmcox.com/2019/08/privacy-and-consent-changes-in-microsoft-office-16-28/</string>
 			<key>pfm_name</key>
 			<string>kFREEnterpriseTelemetryInfoKey</string>
 			<key>pfm_title</key>
@@ -697,7 +697,7 @@ You or administrators may want to suppress the initial warning message.</string>
 			<key>pfm_description_reference</key>
 			<string>Users who are activated with O365 will see a new "Use Intelligent Services?" pop-up dialog in Word, Excel &amp; PowerPoint after updating to 16.17. The net effect of doing this will enable Researcher (Word), Translate (Word, Excel, PowerPoint), Smart Lookup (Word, PowerPoint), and QuickStarter (PowerPoint). Set to TRUE to auto-accept. Requires "PII_And_Intelligent_Services_Preference" as well.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/16.28-Privacy-Consent.key</string>
+			<string>https://www.kevinmcox.com/2019/08/privacy-and-consent-changes-in-microsoft-office-16-28/</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -739,7 +739,7 @@ You or administrators may want to suppress the initial warning message.</string>
 			<key>pfm_description_reference</key>
 			<string>Users who are activated with O365 will see a new "Use Intelligent Services?" pop-up dialog in Word, Excel &amp; PowerPoint after updating to 16.17. The net effect of doing this will enable Researcher (Word), Translate (Word, Excel, PowerPoint), Smart Lookup (Word, PowerPoint), and QuickStarter (PowerPoint). Set to TRUE to auto-accept. Requires "kFREIntelligenceServicesConsentV2Key" as well.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/16.28-Privacy-Consent.key</string>
+			<string>https://www.kevinmcox.com/2019/08/privacy-and-consent-changes-in-microsoft-office-16-28/</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.Powerpoint.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.Powerpoint.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-09-17T08:52:31Z</date>
+	<date>2026-05-20T09:05:42Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -274,7 +274,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<key>pfm_description</key>
 			<string>Suppresses a temporary Privacy and Services Update dialog in 16.27 ONLY. (Was previously used for a similar purpose in 16.13.1 but the key was recycled.)</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/16.28-Privacy-Consent.key</string>
+			<string>https://www.kevinmcox.com/2019/08/privacy-and-consent-changes-in-microsoft-office-16-28/</string>
 			<key>pfm_name</key>
 			<string>kFREEnterpriseTelemetryInfoKey</string>
 			<key>pfm_title</key>
@@ -294,7 +294,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<key>pfm_description_reference</key>
 			<string>Users who are activated with O365 will see a new "Use Intelligent Services?" pop-up dialog in Word, Excel &amp; PowerPoint after updating to 16.17. The net effect of doing this will enable Researcher (Word), Translate (Word, Excel, PowerPoint), Smart Lookup (Word, PowerPoint), and QuickStarter (PowerPoint). Set to TRUE to auto-accept. Requires "PII_And_Intelligent_Services_Preference" as well.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/16.28-Privacy-Consent.key</string>
+			<string>https://www.kevinmcox.com/2019/08/privacy-and-consent-changes-in-microsoft-office-16-28/</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -336,7 +336,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<key>pfm_description_reference</key>
 			<string>Users who are activated with O365 will see a new "Use Intelligent Services?" pop-up dialog in Word, Excel &amp; PowerPoint after updating to 16.17. The net effect of doing this will enable Researcher (Word), Translate (Word, Excel, PowerPoint), Smart Lookup (Word, PowerPoint), and QuickStarter (PowerPoint). Set to TRUE to auto-accept. Requires "kFREIntelligenceServicesConsentV2Key" as well.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/16.28-Privacy-Consent.key</string>
+			<string>https://www.kevinmcox.com/2019/08/privacy-and-consent-changes-in-microsoft-office-16-28/</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.Word.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.Word.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-09-17T08:52:31Z</date>
+	<date>2026-05-20T09:05:42Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -290,7 +290,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<key>pfm_description</key>
 			<string>Suppresses a temporary Privacy and Services Update dialog in 16.27 ONLY. (Was previously used for a similar purpose in 16.13.1 but the key was recycled.)</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/16.28-Privacy-Consent.key</string>
+			<string>https://www.kevinmcox.com/2019/08/privacy-and-consent-changes-in-microsoft-office-16-28/</string>
 			<key>pfm_name</key>
 			<string>kFREEnterpriseTelemetryInfoKey</string>
 			<key>pfm_title</key>
@@ -310,7 +310,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<key>pfm_description_reference</key>
 			<string>Users who are activated with O365 will see a new "Use Intelligent Services?" pop-up dialog in Word, Excel &amp; PowerPoint after updating to 16.17. The net effect of doing this will enable Researcher (Word), Translate (Word, Excel, PowerPoint), Smart Lookup (Word, PowerPoint), and QuickStarter (PowerPoint). Set to TRUE to auto-accept. Requires "PII_And_Intelligent_Services_Preference" as well.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/16.28-Privacy-Consent.key</string>
+			<string>https://www.kevinmcox.com/2019/08/privacy-and-consent-changes-in-microsoft-office-16-28/</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -352,7 +352,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<key>pfm_description_reference</key>
 			<string>Users who are activated with O365 will see a new "Use Intelligent Services?" pop-up dialog in Word, Excel &amp; PowerPoint after updating to 16.17. The net effect of doing this will enable Researcher (Word), Translate (Word, Excel, PowerPoint), Smart Lookup (Word, PowerPoint), and QuickStarter (PowerPoint). Set to TRUE to auto-accept. Requires "kFREIntelligenceServicesConsentV2Key" as well.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/16.28-Privacy-Consent.key</string>
+			<string>https://www.kevinmcox.com/2019/08/privacy-and-consent-changes-in-microsoft-office-16-28/</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2026-02-16T20:29:12Z</date>
+	<date>2026-05-20T09:05:42Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -262,7 +262,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<key>pfm_description_reference</key>
 			<string>Controls whether the user can change the Insider opt- in. If the value is set to TRUE, the user interface is disabled for the user.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/MAU_38.pdf</string>
+			<string>https://learn.microsoft.com/en-us/microsoft-365-apps/mac/mau-preferences#disableinsidercheckbox</string>
 			<key>pfm_name</key>
 			<string>DisableInsiderCheckbox</string>
 			<key>pfm_title</key>
@@ -278,7 +278,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<key>pfm_description</key>
 			<string>Disable this option to make the "Check for Updates" button in unavailable.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.slack.com/archives/C8J5E5VPW/p1525938524000340</string>
+			<string>https://learn.microsoft.com/en-us/microsoft-365-apps/mac/mau-preferences#enablecheckforupdatesbutton</string>
 			<key>pfm_name</key>
 			<string>EnableCheckForUpdatesButton</string>
 			<key>pfm_title</key>
@@ -295,7 +295,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<string>Enabled extended logging for Microsoft AutoUpdate operations.
 Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/MAU_38.pdf</string>
+			<string>https://learn.microsoft.com/en-us/microsoft-365-apps/mac/mau-preferences#extendedlogging</string>
 			<key>pfm_name</key>
 			<string>ExtendedLogging</string>
 			<key>pfm_title</key>
@@ -313,7 +313,7 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 			<key>pfm_description_reference</key>
 			<string>Controls whether updates are detected automatically (default) or manually, and if update packages should be downloaded and installed automatically.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/MAU_38.pdf</string>
+			<string>https://learn.microsoft.com/en-us/microsoft-365-apps/mac/mau-preferences#howtocheck</string>
 			<key>pfm_name</key>
 			<string>HowToCheck</string>
 			<key>pfm_range_list</key>
@@ -339,7 +339,7 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 			<key>pfm_description</key>
 			<string>Force Microsoft AutoUpdate to pull collateral using a custom server. This is good when enterprise wants to have strict control on which version of Office applications get installed. Ensure that a trailing slash is used when specifying the value as this is mandatory. This requires "ChannelName" to be set to "Custom".</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/MAU_CachingServer.pdf</string>
+			<string>https://learn.microsoft.com/en-us/microsoft-365-apps/mac/mau-preferences#manifestserver</string>
 			<key>pfm_name</key>
 			<string>ManifestServer</string>
 			<key>pfm_title</key>
@@ -361,7 +361,7 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 			<key>pfm_description</key>
 			<string>Set to false to send minimal heartbeat data, no application usage, and no environment details. Replaced by "AcknowledgedDataCollectionPolicy" in MAU 4.12.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/16.28-Privacy-Consent.key</string>
+			<string>https://www.kevinmcox.com/2019/08/privacy-and-consent-changes-in-microsoft-office-16-28/</string>
 			<key>pfm_name</key>
 			<string>SendAllTelemetryEnabled</string>
 			<key>pfm_title</key>
@@ -378,8 +378,6 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 			<string>Enable this option to trigger the MAU Daemon when other Office applications are launched.</string>
 			<key>pfm_description_reference</key>
 			<string>Controls whether the ‘Microsoft AU Daemon' should be launched when an Office application is launched. If this value is set to 0, updates will not be detected, regardless of the ‘HowToCheck' preference, and users will need to use the Help -&gt; Check for Updates menu option to see if updates are available.</string>
-			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/MAU_38.pdf</string>
 			<key>pfm_name</key>
 			<string>StartDaemonOnAppLaunch</string>
 			<key>pfm_title</key>
@@ -429,7 +427,7 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 			<key>pfm_description</key>
 			<string>Force Microsoft AutoUpdate to pull update binaries from a custom server. This is good when internet bandwidth is limited. Ensure that a trailing slash is used when specifying the value as this is mandatory.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/MAU_CachingServer.pdf</string>
+			<string>https://learn.microsoft.com/en-us/microsoft-365-apps/mac/mau-preferences#updatecache</string>
 			<key>pfm_name</key>
 			<string>UpdateCache</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.office.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.office.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2024-09-10T08:31:41Z</date>
+	<date>2026-05-20T09:05:42Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -330,7 +330,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<key>pfm_description</key>
 			<string>Controls wether diagnostic data transmission is on or off.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/16.28-Privacy-Consent.key</string>
+			<string>https://www.kevinmcox.com/2019/08/privacy-and-consent-changes-in-microsoft-office-16-28/</string>
 			<key>pfm_name</key>
 			<string>SendAllTelemetryEnabled</string>
 			<key>pfm_note</key>
@@ -636,7 +636,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<key>pfm_description</key>
 			<string>If enabled, completely disables VBA.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/matrix/</string>
+			<string>https://learn.microsoft.com/en-us/microsoft-365-apps/mac/set-preference-macro-security-office-for-mac#disable-visual-basic</string>
 			<key>pfm_name</key>
 			<string>VisualBasicEntirelyDisabled</string>
 			<key>pfm_title</key>
@@ -652,7 +652,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<key>pfm_description</key>
 			<string>The VisualBasicMacroExecutionState1 setting controls whether macros are ever allowed to execute, and what the user experience is when opening a file that contains a macro. By default, macros will only run after the user is presented with an alert when opening a file that contains a macro. The user must make a choice whether to allow or deny macros for each individual file, each time that file is opened.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/VBSecurityControls.pdf</string>
+			<string>https://learn.microsoft.com/en-us/microsoft-365-apps/mac/set-preference-macro-security-office-for-mac#visual-basic-macro-notifications</string>
 			<key>pfm_name</key>
 			<string>VisualBasicMacroExecutionState</string>
 			<key>pfm_range_list</key>
@@ -682,7 +682,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<key>pfm_description_reference</key>
 			<string>The DisableVisualBasicExternalDylibs setting determines if macros are allowed to use a DECLARE statement to bind a Visual Basic symbol name to an external procedure in the local OS. The default value for this setting is to allow binding to external dylibs because many legitimate 3rd party addin vendors use this feature of Visual Basic to add and extend features in Office for Mac. When this setting is set to NO, macros that attempt to use a DECLARE statement will fail with an error at the point where the external procedure is invoked.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/VBSecurityControls.pdf</string>
+			<string>https://learn.microsoft.com/en-us/microsoft-365-apps/mac/set-preference-macro-security-office-for-mac#visual-basic-external-library-bindings</string>
 			<key>pfm_name</key>
 			<string>DisableVisualBasicExternalDylibs</string>
 			<key>pfm_note</key>
@@ -702,7 +702,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<key>pfm_description_reference</key>
 			<string>The AllowVisualBasicToBindToSystem setting determines if macros are allowed to use a DECLARE to bind to the system() OS API. This API allows macros to execute arbitrary external processes and pass them arbitrary data on the command line. The default value for this setting disallows the binding, as the system() API should not be used. When this setting is set to NO, macros that attempt to use system() will fail with an error at the point where system() is invoked.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/VBSecurityControls.pdf</string>
+			<string>https://learn.microsoft.com/en-us/microsoft-365-apps/mac/set-preference-macro-security-office-for-mac#visual-basic-system-bindings</string>
 			<key>pfm_name</key>
 			<string>AllowVisualBasicToBindToSystem</string>
 			<key>pfm_note</key>
@@ -722,7 +722,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<key>pfm_description_reference</key>
 			<string>The DisableVisualBasicToBindToPopen setting determines if macros are allowed to use a DECLARE to bind to the popen() OS API. This API allows macros to execute arbitrary external processes and pass them arbitrary data on the command line. The default value for this setting allows the binding, as at least one 3rd party vendor uses popen to communicate with their own code. When this setting is set to NO, macros that attempt to use popen() will fail with an error at the point where popen() is invoked.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/VBSecurityControls.pdf</string>
+			<string>https://learn.microsoft.com/en-us/microsoft-365-apps/mac/set-preference-macro-security-office-for-mac#visual-basic-pipe-bindings</string>
 			<key>pfm_name</key>
 			<string>DisableVisualBasicToBindToPopen</string>
 			<key>pfm_note</key>
@@ -743,7 +743,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<string>The DisableVisualBasicMacScript setting determines if macros are allowed to invoke the MacScript() Visual Basic API. This API allows macros to execute arbitrary processes via AppleScript by including "do shell script ..." in the AppleScript code. 
 The default value for this setting allows using MacScript, as there are a number of legitimate uses of AppleScript that do not rely on external processes. When this setting is set to NO, macros that attempt to use MacScript will fail with an error at the point where MacScript is invoked.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/VBSecurityControls.pdf</string>
+			<string>https://learn.microsoft.com/en-us/microsoft-365-apps/mac/set-preference-macro-security-office-for-mac#visual-basic-and-applescript</string>
 			<key>pfm_name</key>
 			<string>DisableVisualBasicMacScript</string>
 			<key>pfm_note</key>
@@ -763,7 +763,7 @@ The default value for this setting allows using MacScript, as there are a number
 			<key>pfm_description_reference</key>
 			<string>For Office 2019 only: The VBAObjectModelIsTrusted setting determines if macros are allowed to modify the VB project itself through the VBA object model.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/VBSecurityControls.pdf</string>
+			<string>https://learn.microsoft.com/en-us/microsoft-365-apps/mac/set-preference-macro-security-office-for-mac#vba-object-model</string>
 			<key>pfm_name</key>
 			<string>VBAObjectModelIsTrusted</string>
 			<key>pfm_note</key>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.onenote.mac.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.onenote.mac.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-09-17T08:52:31Z</date>
+	<date>2026-05-20T09:05:42Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -258,7 +258,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<key>pfm_description</key>
 			<string>Suppresses a temporary Privacy and Services Update dialog in 16.27 ONLY. (Was previously used for a similar purpose in 16.13.1 but the key was recycled.)</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/16.28-Privacy-Consent.key</string>
+			<string>https://www.kevinmcox.com/2019/08/privacy-and-consent-changes-in-microsoft-office-16-28/</string>
 			<key>pfm_name</key>
 			<string>kFREEnterpriseTelemetryInfoKey</string>
 			<key>pfm_title</key>
@@ -278,7 +278,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<key>pfm_description_reference</key>
 			<string>Users who are activated with O365 will see a new "Use Intelligent Services?" pop-up dialog in Word, Excel &amp; PowerPoint after updating to 16.17. The net effect of doing this will enable Researcher (Word), Translate (Word, Excel, PowerPoint), Smart Lookup (Word, PowerPoint), and QuickStarter (PowerPoint). Set to TRUE to auto-accept. Requires "PII_And_Intelligent_Services_Preference" as well.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/16.28-Privacy-Consent.key</string>
+			<string>https://www.kevinmcox.com/2019/08/privacy-and-consent-changes-in-microsoft-office-16-28/</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -320,7 +320,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<key>pfm_description_reference</key>
 			<string>Users who are activated with O365 will see a new "Use Intelligent Services?" pop-up dialog in Word, Excel &amp; PowerPoint after updating to 16.17. The net effect of doing this will enable Researcher (Word), Translate (Word, Excel, PowerPoint), Smart Lookup (Word, PowerPoint), and QuickStarter (PowerPoint). Set to TRUE to auto-accept. Requires "kFREIntelligenceServicesConsentV2Key" as well.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/16.28-Privacy-Consent.key</string>
+			<string>https://www.kevinmcox.com/2019/08/privacy-and-consent-changes-in-microsoft-office-16-28/</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>


### PR DESCRIPTION
This PR replaces broken documentation URLs in the Microsoft Office manifests.

Official URLs were used where newly available. @kevinmcox, a post from your blog discussing certain now-deprecated keys was used to document them as there is no official source. We can also remove these URLs altogether if you prefer.