### PR TITLE
Elevate24 2.5 Update

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.jigsaw24.Elevate24.plist
+++ b/Manifests/ManagedPreferencesApplications/com.jigsaw24.Elevate24.plist
@@ -113,7 +113,7 @@
 	RK5CYII=
 	</data>
 	<key>pfm_last_modified</key>
-	<date>2026-02-26T12:00:00Z</date>
+	<date>2026-06-03T12:00:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -295,16 +295,18 @@ During a profile replacement, the system updates payloads with the same 'Payload
 				<array>
 					<string>enableReason</string>
 					<string>Enabletimelist</string>
-					<string>Block Extend</string>
+					<string>blockExtend</string>
+					<string>AllowCliElevation</string>
+					<string>DisableUserElevation</string>
 					<string>Sessiontime</string>
 					<string>times</string>
 					<string>reasons</string>
 					<string>sessionExpiryReminder</string>
+					<string>AllowUserDefinedScripts</string>
 					<string>ElevateScriptPath</string>
 					<string>ElevateScriptHash</string>
 					<string>DemoteScriptPath</string>
 					<string>DemoteScriptHash</string>
-					<string>AllowUserDefinedScripts</string>
 				</array>
 			</dict>
 			<key>pfm_type</key>
@@ -447,6 +449,38 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_app_min</key>
+			<string>2.5.0</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Elevate24 2.5+ Only. When enabled, the Elevate24 menubar UI is hidden and cannot be launched manually from /Applications. End users will have no visible way to request elevation, view their session status, or interact with Elevate24 directly. The underlying agent continues to run in the background, enforcing session policies and authorisation rules as normal.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.jigsaw24.com/Elevate24/Documentation/Elevate24%20Configuration/4%20Elevate24%20-%20Customisation.html#session-customisation</string>
+			<key>pfm_name</key>
+			<string>DisableUserElevation</string>
+			<key>pfm_title</key>
+			<string>Disable User Elevation</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>2.5.0</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Elevate24 2.5+ Only. When enabled, allows user to elevate from the command-line.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.jigsaw24.com/Elevate24/Documentation/Elevate24%20Configuration/4%20Elevate24%20-%20Customisation.html#session-customisation</string>
+			<key>pfm_name</key>
+			<string>AllowCliElevation</string>
+			<key>pfm_title</key>
+			<string>Allow CLI Elevation</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
@@ -569,6 +603,20 @@ During a profile replacement, the system updates payloads with the same 'Payload
 		<dict>
 			<key>pfm_app_min</key>
 			<string>2.4.0</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Elevate24 2.4+ Only. When enabled, allows users to specify their own elevation and demotion script paths in addition to any admin-defined scripts. If scripts are configured at both the admin and user level, all scripts will execute. When disabled, only admin-defined scripts (ElevateScriptPath and DemoteScriptPath) will be used.</string>
+			<key>pfm_name</key>
+			<string>AllowUserDefinedScripts</string>
+			<key>pfm_title</key>
+			<string>Allow User Defined Scripts</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>2.4.0</string>
 			<key>pfm_description</key>
 			<string>Elevate24 2.4+ Only. Specify the full file path to a script that will be executed automatically when a user's session is elevated to admin. This can be used to perform actions such as logging, launching tools, or configuring the environment at the point of elevation.</string>
 			<key>pfm_name</key>
@@ -621,20 +669,6 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<string>string</string>
 			<key>pfm_value_placeholder</key>
 			<string>SHA256 hash</string>
-		</dict>
-		<dict>
-			<key>pfm_app_min</key>
-			<string>2.4.0</string>
-			<key>pfm_default</key>
-			<false/>
-			<key>pfm_description</key>
-			<string>Elevate24 2.4+ Only. When enabled, allows users to specify their own elevation and demotion script paths in addition to any admin-defined scripts. If scripts are configured at both the admin and user level, all scripts will execute. When disabled, only admin-defined scripts (ElevateScriptPath and DemoteScriptPath) will be used.</string>
-			<key>pfm_name</key>
-			<string>AllowUserDefinedScripts</string>
-			<key>pfm_title</key>
-			<string>Allow User Defined Scripts</string>
-			<key>pfm_type</key>
-			<string>boolean</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
@@ -1009,6 +1043,6 @@ During a profile replacement, the system updates payloads with the same 'Payload
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>5</integer>
+	<integer>6</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/com.jigsaw24.ElevateSecurityLogs.plist
+++ b/Manifests/ManagedPreferencesApplications/com.jigsaw24.ElevateSecurityLogs.plist
@@ -254,7 +254,6 @@ A profile can consist of payloads with different version numbers. For example, c
 				<key>Authorisation Rules</key>
 				<array>
 			    	<string>HideBlockedEventHistory</string>
-					<string>silentBlock</string>
 					<string>FileOperationRules</string>
 					<string>ExecuteProcessRules</string>
 				</array>
@@ -524,20 +523,6 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_default</key>
-			<false/>
-			<key>pfm_description</key>
-			<string>When enabled, hides the end user notifcation when a rule is triggered.</string>
-			<key>pfm_documentation_url</key>
-			<string>https://docs.jigsaw24.com/Elevate24/Documentation/Elevate24%20Monitoring/5%20Elevate24%20Session%20Monitoring%20-%20Authorisation%20Rules.html#monitoring-authorisation-rules</string>
-			<key>pfm_name</key>
-			<string>silentBlock</string>
-			<key>pfm_title</key>
-			<string>Silent Block</string>
-			<key>pfm_type</key>
-			<string>boolean</string>
-		</dict>
-		<dict>
 			<key>pfm_description</key>
 			<string>Rules to restrict file operations. Allow rules can be used in conjunction with block rules to allow a process to execute under the specified conditions.
 			
@@ -706,6 +691,14 @@ Multiple arguments can be specified by seperating them with a comma.</string>
 							<string>alwaysActive</string>
 							<key>pfm_title</key>
 							<string>Always Active</string>
+							<key>pfm_type</key>
+							<string>boolean</string>
+						</dict>
+						<dict>
+							<key>pfm_name</key>
+							<string>silentBlock</string>
+							<key>pfm_title</key>
+							<string>Silent Block</string>
 							<key>pfm_type</key>
 							<string>boolean</string>
 						</dict>

--- a/Manifests/ManagedPreferencesApplications/com.jigsaw24.ElevateSecurityLogs.plist
+++ b/Manifests/ManagedPreferencesApplications/com.jigsaw24.ElevateSecurityLogs.plist
@@ -115,7 +115,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2026-02-26T12:00:00Z</date>
+	<date>2026-06-03T12:00:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -253,6 +253,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<dict>
 				<key>Authorisation Rules</key>
 				<array>
+			    	<string>HideBlockedEventHistory</string>
+					<string>silentBlock</string>
 					<string>FileOperationRules</string>
 					<string>ExecuteProcessRules</string>
 				</array>
@@ -271,11 +273,9 @@ A profile can consist of payloads with different version numbers. For example, c
 					<string>SelfProtectionRules</string>
 					<string>DisableAll</string>
 					<string>UploadEventsToJigsaw</string>
-					<string>EnableArchive</string>
-					<string>MaxArchiveAge</string>
 					<string>UploadOnHotspot</string>
 				</array>
-				<key>Upload to Other</key>
+				<key>Upload to SIEM</key>
 				<array>
 					<string>siemUploadURL</string>
 					<string>siemUploadHeaders</string>
@@ -499,36 +499,6 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Enables the local retention of Events after they have been uploaded to Jigsaw24/SIEM.</string>
-			<key>pfm_documentation_url</key>
-			<string>https://docs.jigsaw24.com/Elevate24/Documentation/Elevate24%20Monitoring/2%20Elevate24%20Session%20Monitoring%20-%20General.html#monitoring-general-settings</string>
-			<key>pfm_name</key>
-			<string>EnableArchive</string>
-			<key>pfm_title</key>
-			<string>Enable Local Retention of Events</string>
-			<key>pfm_type</key>
-			<string>boolean</string>
-		</dict>
-		<dict>
-			<key>pfm_default</key>
-			<integer>7</integer>
-			<key>pfm_description</key>
-			<string>Sets maximum age of events retained locally.</string>
-			<key>pfm_documentation_url</key>
-			<string>https://docs.jigsaw24.com/Elevate24/Documentation/Elevate24%20Monitoring/2%20Elevate24%20Session%20Monitoring%20-%20General.html#monitoring-general-settings</string>
-			<key>pfm_name</key>
-			<string>MaxArchiveAge</string>
-			<key>pfm_title</key>
-			<string>Maximum Age of Retained Events (Days)</string>
-			<key>pfm_type</key>
-			<string>integer</string>
-			<key>pfm_value_placeholder</key>
-			<string>7</string>
-		</dict>
-		<dict>
-			<key>pfm_default</key>
-			<false/>
-			<key>pfm_description</key>
 			<string>Upload Events when connected to iPhone personal hotspot.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://docs.jigsaw24.com/Elevate24/Documentation/Elevate24%20Monitoring/2%20Elevate24%20Session%20Monitoring%20-%20General.html#monitoring-general-settings</string>
@@ -536,6 +506,34 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>UploadOnHotspot</string>
 			<key>pfm_title</key>
 			<string>Allow Upload Data on Hotspot connection</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>When enabled, hides the blocked events history from the Elevate24 UI.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.jigsaw24.com/Elevate24/Documentation/Elevate24%20Monitoring/5%20Elevate24%20Session%20Monitoring%20-%20Authorisation%20Rules.html#monitoring-authorisation-rules</string>
+			<key>pfm_name</key>
+			<string>HideBlockedEventHistory</string>
+			<key>pfm_title</key>
+			<string>Hide Blocked Event History</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>When enabled, hides the end user notifcation when a rule is triggered.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.jigsaw24.com/Elevate24/Documentation/Elevate24%20Monitoring/5%20Elevate24%20Session%20Monitoring%20-%20Authorisation%20Rules.html#monitoring-authorisation-rules</string>
+			<key>pfm_name</key>
+			<string>silentBlock</string>
+			<key>pfm_title</key>
+			<string>Silent Block</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
@@ -952,6 +950,6 @@ Multiple arguments can be specified by seperating them with a comma.</string>
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>5</integer>
+	<integer>6</integer>
 </dict>
 </plist>


### PR DESCRIPTION
Elevate24 2.5 Update. 

Updates to com.jigsaw24.Elevate24.plist & com.jigsaw24.ElevateSecurityLogs.plist

Moved a few bits around for structure and added new keys. 

I've deleted two keys entirely, this is expected and want these fully removed. These are - 				
<string>EnableArchive</string>
<string>MaxArchiveAge</string>

Thanks 