### PR TITLE
Fix the default value of DIALPAD_DISABLE_UPDATES

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.electron.dialpad.plist
+++ b/Manifests/ManagedPreferencesApplications/com.electron.dialpad.plist
@@ -15,7 +15,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2026-06-09T13:00:23Z</date>
+	<date>2026-07-29T02:00:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -124,7 +124,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string>Prevents Dialpad from automatically checking for updates.</string>
 			<key>pfm_documentation_url</key>


### PR DESCRIPTION
Dialpad does not disable updates by default. `DIALPAD_DISABLE_UPDATES` must be set to true to disable updates